### PR TITLE
refactor: replace HTTP exceptions with domain exceptions in Service/UseCase layers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -370,6 +370,39 @@ The `AnalysisUseCase` uses `Prisma.$queryRaw` with `Prisma.raw()` for complex an
 - **Rationale**: Prisma's `groupBy` does not support JOINs or computed columns (e.g., `win_count / total_count`), making raw SQL necessary for victory rate analysis.
 - **Testing**: Raw SQL query builders must have comprehensive unit tests covering all groupBy/sortBy combinations and edge cases.
 
+#### Exception Handling Policy
+
+**CRITICAL: Service/UseCase layers must NOT throw HTTP exceptions (e.g., `BadRequestException`, `NotFoundException`, `ForbiddenException`)**
+
+HTTP exceptions are controller-layer concerns. Service and UseCase layers throw domain-specific exceptions, which are mapped to HTTP responses by `DomainExceptionFilter`.
+
+**Domain Exception Classes** (`src/common/exceptions/`):
+
+| Domain Exception | HTTP Mapping | Use Case |
+| --- | --- | --- |
+| `EntityNotFoundException` | 404 Not Found | Entity lookup failed |
+| `DuplicateEntityException` | 409 Conflict | Unique constraint violation (e.g., email) |
+| `ValidationException` | 400 Bad Request | Invalid FK references, invalid params for raw SQL |
+| `OwnershipViolationException` | 403 Forbidden | User does not own the resource |
+| `AuthenticationException` | 401 Unauthorized | Invalid credentials |
+
+**Rules**:
+- Service/UseCase: throw domain exceptions only (`import from '../common/exceptions'`)
+- Controller: may throw NestJS HTTP exceptions directly for controller-specific validation
+- `DomainExceptionFilter`: registered globally in `main.ts`, maps domain exceptions to HTTP responses
+- `PrismaExceptionFilter`: handles Prisma-level errors (P2002, P2025, etc.) separately
+- `InternalServerErrorException` (NestJS): acceptable for truly unexpected errors that don't map to domain concepts
+
+```typescript
+// ❌ Bad: HTTP exception in Service/UseCase
+import { BadRequestException } from '@nestjs/common';
+throw new BadRequestException('Invalid rule IDs: 1');
+
+// ✅ Good: Domain exception in Service/UseCase
+import { ValidationException } from '../common/exceptions';
+throw new ValidationException('Invalid rule IDs: 1');
+```
+
 ### TypeScript Best Practices
 
 #### Type Safety Rules

--- a/apps/backend/src/analysis/analysis.usecase.spec.ts
+++ b/apps/backend/src/analysis/analysis.usecase.spec.ts
@@ -1,7 +1,7 @@
-import { BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { AnalysisUseCase } from './analysis.usecase';
 import { PrismaService } from '../prisma/prisma.service';
+import { ValidationException } from '../common/exceptions';
 import {
   GroupByField,
   VictoryRateSortBy,
@@ -174,38 +174,38 @@ describe('AnalysisUseCase', () => {
     });
 
     describe('parameter validation', () => {
-      it('should throw BadRequestException for invalid groupBy field', async () => {
+      it('should throw ValidationException for invalid groupBy field', async () => {
         const userId = 'test-user-id';
         const groupBy = ['invalidField'] as unknown as GroupByField[];
 
         await expect(
           useCase.getVictoryRate({ userId, groupBy }),
-        ).rejects.toThrow(BadRequestException);
+        ).rejects.toThrow(ValidationException);
         await expect(
           useCase.getVictoryRate({ userId, groupBy }),
         ).rejects.toThrow('Invalid groupBy field: invalidField');
         expect(prismaService.$queryRaw).not.toHaveBeenCalled();
       });
 
-      it('should throw BadRequestException for invalid sortBy field', async () => {
+      it('should throw ValidationException for invalid sortBy field', async () => {
         const userId = 'test-user-id';
         const groupBy = [GroupByField.RULE];
         const sortBy = 'DROP TABLE users' as unknown as VictoryRateSortBy;
 
         await expect(
           useCase.getVictoryRate({ userId, groupBy, sortBy }),
-        ).rejects.toThrow(BadRequestException);
+        ).rejects.toThrow(ValidationException);
         expect(prismaService.$queryRaw).not.toHaveBeenCalled();
       });
 
-      it('should throw BadRequestException for invalid sortOrder', async () => {
+      it('should throw ValidationException for invalid sortOrder', async () => {
         const userId = 'test-user-id';
         const groupBy = [GroupByField.RULE];
         const sortOrder = 'invalid' as unknown as SortOrder;
 
         await expect(
           useCase.getVictoryRate({ userId, groupBy, sortOrder }),
-        ).rejects.toThrow(BadRequestException);
+        ).rejects.toThrow(ValidationException);
         expect(prismaService.$queryRaw).not.toHaveBeenCalled();
       });
     });

--- a/apps/backend/src/analysis/analysis.usecase.ts
+++ b/apps/backend/src/analysis/analysis.usecase.ts
@@ -1,4 +1,5 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { ValidationException } from '../common/exceptions';
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import {
@@ -119,16 +120,16 @@ export class AnalysisUseCase {
   private validateParams(params: GetVictoryRateParams): void {
     for (const field of params.groupBy) {
       if (!ALLOWED_GROUP_BY_FIELDS.has(field)) {
-        throw new BadRequestException(`Invalid groupBy field: ${field}`);
+        throw new ValidationException(`Invalid groupBy field: ${field}`);
       }
     }
 
     if (params.sortBy && !ALLOWED_SORT_BY_FIELDS.has(params.sortBy)) {
-      throw new BadRequestException(`Invalid sortBy field: ${params.sortBy}`);
+      throw new ValidationException(`Invalid sortBy field: ${params.sortBy}`);
     }
 
     if (params.sortOrder && !ALLOWED_SORT_ORDERS.has(params.sortOrder)) {
-      throw new BadRequestException(`Invalid sortOrder: ${params.sortOrder}`);
+      throw new ValidationException(`Invalid sortOrder: ${params.sortOrder}`);
     }
   }
 

--- a/apps/backend/src/auth/auth.service.spec.ts
+++ b/apps/backend/src/auth/auth.service.spec.ts
@@ -1,5 +1,5 @@
-import { UnauthorizedException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { AuthenticationException } from '../common/exceptions';
 import * as bcrypt from 'bcrypt';
 import { TokenService } from '../token/token.service';
 import { UserService } from '../user/user.service';
@@ -79,35 +79,35 @@ describe('AuthService', () => {
       );
     });
 
-    it('should throw UnauthorizedException when user does not exist', async () => {
+    it('should throw AuthenticationException when user does not exist', async () => {
       userService.findByEmail.mockResolvedValue(null);
 
       await expect(
         service.validateUser('test@example.com', 'password'),
-      ).rejects.toThrow(UnauthorizedException);
+      ).rejects.toThrow(AuthenticationException);
 
       expect(userService.findByEmail).toHaveBeenCalledWith('test@example.com');
       expect(bcrypt.compare).not.toHaveBeenCalled();
     });
 
-    it('should throw UnauthorizedException when user has no secret', async () => {
+    it('should throw AuthenticationException when user has no secret', async () => {
       const userWithoutSecret = { ...mockUser, secret: null };
       userService.findByEmail.mockResolvedValue(userWithoutSecret);
 
       await expect(
         service.validateUser('test@example.com', 'password'),
-      ).rejects.toThrow(UnauthorizedException);
+      ).rejects.toThrow(AuthenticationException);
 
       expect(bcrypt.compare).not.toHaveBeenCalled();
     });
 
-    it('should throw UnauthorizedException when password is invalid', async () => {
+    it('should throw AuthenticationException when password is invalid', async () => {
       userService.findByEmail.mockResolvedValue(mockUser);
       (bcrypt.compare as jest.Mock).mockResolvedValue(false);
 
       await expect(
         service.validateUser('test@example.com', 'wrong-password'),
-      ).rejects.toThrow(UnauthorizedException);
+      ).rejects.toThrow(AuthenticationException);
 
       expect(bcrypt.compare).toHaveBeenCalledWith(
         'wrong-password',
@@ -144,16 +144,16 @@ describe('AuthService', () => {
       });
     });
 
-    it('should throw UnauthorizedException on invalid credentials', async () => {
+    it('should throw AuthenticationException on invalid credentials', async () => {
       userService.findByEmail.mockResolvedValue(mockUser);
       (bcrypt.compare as jest.Mock).mockResolvedValue(false);
 
       await expect(service.login(request)).rejects.toThrow(
-        UnauthorizedException,
+        AuthenticationException,
       );
     });
 
-    it('should throw UnauthorizedException when user has no secret', async () => {
+    it('should throw AuthenticationException when user has no secret', async () => {
       const request: LoginRequest = {
         email: 'test@example.com',
         password: 'password',
@@ -162,11 +162,11 @@ describe('AuthService', () => {
       const userWithoutSecret = { ...mockUser, secret: null };
       userService.findByEmail.mockResolvedValue(userWithoutSecret);
 
-      await expect(service.login(request)).rejects.toThrow(UnauthorizedException);
+      await expect(service.login(request)).rejects.toThrow(AuthenticationException);
       expect(tokenService.generateTokens).not.toHaveBeenCalled();
     });
 
-    it('should throw UnauthorizedException when user does not exist during login', async () => {
+    it('should throw AuthenticationException when user does not exist during login', async () => {
       const request: LoginRequest = {
         email: 'nonexistent@example.com',
         password: 'password',
@@ -174,7 +174,7 @@ describe('AuthService', () => {
 
       userService.findByEmail.mockResolvedValue(null);
 
-      await expect(service.login(request)).rejects.toThrow(UnauthorizedException);
+      await expect(service.login(request)).rejects.toThrow(AuthenticationException);
       expect(tokenService.generateTokens).not.toHaveBeenCalled();
     });
   });

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { AuthenticationException } from '../common/exceptions';
 import * as bcrypt from 'bcrypt';
 import { TokenService } from '../token/token.service';
 import { UserService } from '../user/user.service';
@@ -15,7 +16,7 @@ export class AuthService {
     const user = await this.userService.findByEmail(email);
 
     if (!user || !user.secret) {
-      throw new UnauthorizedException('Invalid credentials');
+      throw new AuthenticationException('Invalid credentials');
     }
 
     const isPasswordValid = await bcrypt.compare(
@@ -24,7 +25,7 @@ export class AuthService {
     );
 
     if (!isPasswordValid) {
-      throw new UnauthorizedException('Invalid credentials');
+      throw new AuthenticationException('Invalid credentials');
     }
 
     return user.id;

--- a/apps/backend/src/common/exceptions/domain.exception.ts
+++ b/apps/backend/src/common/exceptions/domain.exception.ts
@@ -1,0 +1,63 @@
+/**
+ * Base class for all domain exceptions.
+ * Domain exceptions are HTTP-agnostic and represent business logic errors.
+ * They are mapped to HTTP responses by DomainExceptionFilter.
+ */
+export class DomainException extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = this.constructor.name;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/**
+ * Thrown when a requested entity does not exist.
+ * Mapped to HTTP 404 Not Found.
+ */
+export class EntityNotFoundException extends DomainException {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+/**
+ * Thrown when an operation would create a duplicate entity.
+ * Mapped to HTTP 409 Conflict.
+ */
+export class DuplicateEntityException extends DomainException {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+/**
+ * Thrown when input validation fails at the business logic level.
+ * (e.g., invalid FK references, invalid enum values for raw SQL)
+ * Mapped to HTTP 400 Bad Request.
+ */
+export class ValidationException extends DomainException {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+/**
+ * Thrown when a user attempts to access a resource they do not own.
+ * Mapped to HTTP 403 Forbidden.
+ */
+export class OwnershipViolationException extends DomainException {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+/**
+ * Thrown when authentication fails (invalid credentials, missing secret, etc.).
+ * Mapped to HTTP 401 Unauthorized.
+ */
+export class AuthenticationException extends DomainException {
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/apps/backend/src/common/exceptions/index.ts
+++ b/apps/backend/src/common/exceptions/index.ts
@@ -1,0 +1,8 @@
+export {
+  DomainException,
+  EntityNotFoundException,
+  DuplicateEntityException,
+  ValidationException,
+  OwnershipViolationException,
+  AuthenticationException,
+} from './domain.exception';

--- a/apps/backend/src/common/filters/domain-exception.filter.spec.ts
+++ b/apps/backend/src/common/filters/domain-exception.filter.spec.ts
@@ -1,0 +1,126 @@
+import { ArgumentsHost, HttpStatus } from '@nestjs/common';
+import { DomainExceptionFilter } from './domain-exception.filter';
+import {
+  DomainException,
+  EntityNotFoundException,
+  DuplicateEntityException,
+  ValidationException,
+  OwnershipViolationException,
+  AuthenticationException,
+} from '../exceptions';
+
+describe('DomainExceptionFilter', () => {
+  let filter: DomainExceptionFilter;
+  let mockResponse: {
+    status: jest.Mock;
+    json: jest.Mock;
+  };
+  let mockHost: ArgumentsHost;
+
+  beforeEach(() => {
+    filter = new DomainExceptionFilter();
+    mockResponse = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+    mockHost = {
+      switchToHttp: () => ({
+        getResponse: () => mockResponse,
+        getRequest: jest.fn(),
+        getNext: jest.fn(),
+      }),
+      getArgs: jest.fn(),
+      getArgByIndex: jest.fn(),
+      switchToRpc: jest.fn(),
+      switchToWs: jest.fn(),
+      getType: jest.fn(),
+    } as unknown as ArgumentsHost;
+  });
+
+  it('should handle EntityNotFoundException as 404', () => {
+    const exception = new EntityNotFoundException('User not found');
+
+    filter.catch(exception, mockHost);
+
+    expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.NOT_FOUND);
+    expect(mockResponse.json).toHaveBeenCalledWith({
+      statusCode: HttpStatus.NOT_FOUND,
+      message: 'User not found',
+      error: 'Not Found',
+    });
+  });
+
+  it('should handle DuplicateEntityException as 409', () => {
+    const exception = new DuplicateEntityException('Email already exists');
+
+    filter.catch(exception, mockHost);
+
+    expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.CONFLICT);
+    expect(mockResponse.json).toHaveBeenCalledWith({
+      statusCode: HttpStatus.CONFLICT,
+      message: 'Email already exists',
+      error: 'Conflict',
+    });
+  });
+
+  it('should handle ValidationException as 400', () => {
+    const exception = new ValidationException('Invalid rule IDs: 1, 2');
+
+    filter.catch(exception, mockHost);
+
+    expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
+    expect(mockResponse.json).toHaveBeenCalledWith({
+      statusCode: HttpStatus.BAD_REQUEST,
+      message: 'Invalid rule IDs: 1, 2',
+      error: 'Bad Request',
+    });
+  });
+
+  it('should handle OwnershipViolationException as 403', () => {
+    const exception = new OwnershipViolationException(
+      'Not all matches belong to the user',
+    );
+
+    filter.catch(exception, mockHost);
+
+    expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.FORBIDDEN);
+    expect(mockResponse.json).toHaveBeenCalledWith({
+      statusCode: HttpStatus.FORBIDDEN,
+      message: 'Not all matches belong to the user',
+      error: 'Forbidden',
+    });
+  });
+
+  it('should handle AuthenticationException as 401', () => {
+    const exception = new AuthenticationException('Invalid credentials');
+
+    filter.catch(exception, mockHost);
+
+    expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.UNAUTHORIZED);
+    expect(mockResponse.json).toHaveBeenCalledWith({
+      statusCode: HttpStatus.UNAUTHORIZED,
+      message: 'Invalid credentials',
+      error: 'Unauthorized',
+    });
+  });
+
+  it('should handle unknown DomainException subclass as 500', () => {
+    class UnknownDomainException extends DomainException {
+      constructor() {
+        super('Something went wrong');
+      }
+    }
+    const exception = new UnknownDomainException();
+
+    filter.catch(exception, mockHost);
+
+    expect(mockResponse.status).toHaveBeenCalledWith(
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+    expect(mockResponse.json).toHaveBeenCalledWith({
+      statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+      message: 'Something went wrong',
+      error: 'Internal Server Error',
+    });
+  });
+});

--- a/apps/backend/src/common/filters/domain-exception.filter.ts
+++ b/apps/backend/src/common/filters/domain-exception.filter.ts
@@ -1,0 +1,62 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpStatus,
+} from '@nestjs/common';
+import { Response } from 'express';
+import {
+  DomainException,
+  EntityNotFoundException,
+  DuplicateEntityException,
+  ValidationException,
+  OwnershipViolationException,
+  AuthenticationException,
+} from '../exceptions';
+
+const EXCEPTION_STATUS_MAP = new Map<
+  new (...args: string[]) => DomainException,
+  { status: HttpStatus; error: string }
+>([
+  [
+    EntityNotFoundException,
+    { status: HttpStatus.NOT_FOUND, error: 'Not Found' },
+  ],
+  [
+    DuplicateEntityException,
+    { status: HttpStatus.CONFLICT, error: 'Conflict' },
+  ],
+  [
+    ValidationException,
+    { status: HttpStatus.BAD_REQUEST, error: 'Bad Request' },
+  ],
+  [
+    OwnershipViolationException,
+    { status: HttpStatus.FORBIDDEN, error: 'Forbidden' },
+  ],
+  [
+    AuthenticationException,
+    { status: HttpStatus.UNAUTHORIZED, error: 'Unauthorized' },
+  ],
+]);
+
+@Catch(DomainException)
+export class DomainExceptionFilter implements ExceptionFilter {
+  catch(exception: DomainException, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+
+    const mapping = EXCEPTION_STATUS_MAP.get(
+      exception.constructor as new (...args: string[]) => DomainException,
+    );
+
+    const status = mapping?.status ?? HttpStatus.INTERNAL_SERVER_ERROR;
+    const error = mapping?.error ?? 'Internal Server Error';
+
+    response.status(status).json({
+      statusCode: status,
+      message: exception.message,
+      error,
+    });
+  }
+}

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -4,6 +4,7 @@ import { NestFactory } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import cookieParser from 'cookie-parser';
 import { AppModule } from './app.module';
+import { DomainExceptionFilter } from './common/filters/domain-exception.filter';
 import { PrismaExceptionFilter } from './common/filters/prisma-exception.filter';
 
 async function bootstrap() {
@@ -31,7 +32,10 @@ async function bootstrap() {
     }),
   );
 
-  app.useGlobalFilters(new PrismaExceptionFilter());
+  app.useGlobalFilters(
+    new PrismaExceptionFilter(),
+    new DomainExceptionFilter(),
+  );
 
   const config = new DocumentBuilder()
     .setTitle('Re Spla Analysis API')

--- a/apps/backend/src/match/match.service.spec.ts
+++ b/apps/backend/src/match/match.service.spec.ts
@@ -1,6 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { BadRequestException, ForbiddenException } from '@nestjs/common';
 import { MatchService } from './match.service';
+import {
+  OwnershipViolationException,
+  ValidationException,
+} from '../common/exceptions';
 import { MatchUseCase } from './match.usecase';
 import { MatchRepository } from './match.repository';
 import {
@@ -323,11 +326,11 @@ describe('MatchService', () => {
       };
 
       matchUseCase.bulkCreateMatches.mockRejectedValue(
-        new BadRequestException('Invalid rule IDs: 999'),
+        new ValidationException('Invalid rule IDs: 999'),
       );
 
       await expect(service.bulkCreateMatches(userId, request)).rejects.toThrow(
-        BadRequestException,
+        ValidationException,
       );
     });
   });
@@ -364,7 +367,7 @@ describe('MatchService', () => {
       expect(result).toEqual({ success: true });
     });
 
-    it('should throw ForbiddenException when user does not own all matches', async () => {
+    it('should throw OwnershipViolationException when user does not own all matches', async () => {
       const userId = 'test-user-id';
       const request: BulkUpdateMatchesRequest = {
         matches: [
@@ -393,7 +396,7 @@ describe('MatchService', () => {
       matchRepository.findByUserIdAndIds.mockResolvedValue([mockMatch]);
 
       await expect(service.bulkUpdateMatches(userId, request)).rejects.toThrow(
-        ForbiddenException,
+        OwnershipViolationException,
       );
       expect(matchUseCase.bulkUpdateMatches).not.toHaveBeenCalled();
     });
@@ -447,7 +450,7 @@ describe('MatchService', () => {
       expect(result).toEqual({ success: true });
     });
 
-    it('should throw ForbiddenException when user does not own all matches', async () => {
+    it('should throw OwnershipViolationException when user does not own all matches', async () => {
       const userId = 'test-user-id';
       const request: BulkDeleteMatchesRequest = {
         ids: ['match-1', 'match-2'],
@@ -457,7 +460,7 @@ describe('MatchService', () => {
       matchRepository.findByUserIdAndIds.mockResolvedValue([mockMatch]);
 
       await expect(service.bulkDeleteMatches(userId, request)).rejects.toThrow(
-        ForbiddenException,
+        OwnershipViolationException,
       );
       expect(matchRepository.deleteMany).not.toHaveBeenCalled();
     });

--- a/apps/backend/src/match/match.service.ts
+++ b/apps/backend/src/match/match.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, ForbiddenException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { OwnershipViolationException } from '../common/exceptions';
 import { MatchUseCase } from './match.usecase';
 import { MatchRepository } from './match.repository';
 import {
@@ -106,7 +107,7 @@ export class MatchService {
       matchIds,
     );
     if (ownedMatches.length !== matchIds.length) {
-      throw new ForbiddenException('Not all matches belong to the user');
+      throw new OwnershipViolationException('Not all matches belong to the user');
     }
   }
 }

--- a/apps/backend/src/match/match.usecase.spec.ts
+++ b/apps/backend/src/match/match.usecase.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { BadRequestException } from '@nestjs/common';
 import { MatchUseCase } from './match.usecase';
+import { ValidationException } from '../common/exceptions';
 import { MatchRepository } from './match.repository';
 import { RuleRepository } from '../rule/rule.repository';
 import { WeaponRepository } from '../weapon/weapon.repository';
@@ -155,7 +155,7 @@ describe('MatchUseCase', () => {
       );
     });
 
-    it('should throw BadRequestException when rule ID is invalid', async () => {
+    it('should throw ValidationException when rule ID is invalid', async () => {
       const userId = 'test-user-id';
       const matches = [mockMatchData];
 
@@ -165,14 +165,14 @@ describe('MatchUseCase', () => {
       battleTypeRepository.findByIds.mockResolvedValue([mockBattleType]);
 
       await expect(useCase.bulkCreateMatches(userId, matches)).rejects.toThrow(
-        BadRequestException,
+        ValidationException,
       );
       await expect(useCase.bulkCreateMatches(userId, matches)).rejects.toThrow(
         'Invalid rule IDs: 1',
       );
     });
 
-    it('should throw BadRequestException when weapon ID is invalid', async () => {
+    it('should throw ValidationException when weapon ID is invalid', async () => {
       const userId = 'test-user-id';
       const matches = [mockMatchData];
 
@@ -182,14 +182,14 @@ describe('MatchUseCase', () => {
       battleTypeRepository.findByIds.mockResolvedValue([mockBattleType]);
 
       await expect(useCase.bulkCreateMatches(userId, matches)).rejects.toThrow(
-        BadRequestException,
+        ValidationException,
       );
       await expect(useCase.bulkCreateMatches(userId, matches)).rejects.toThrow(
         'Invalid weapon IDs: 1',
       );
     });
 
-    it('should throw BadRequestException when stage ID is invalid', async () => {
+    it('should throw ValidationException when stage ID is invalid', async () => {
       const userId = 'test-user-id';
       const matches = [mockMatchData];
 
@@ -199,14 +199,14 @@ describe('MatchUseCase', () => {
       battleTypeRepository.findByIds.mockResolvedValue([mockBattleType]);
 
       await expect(useCase.bulkCreateMatches(userId, matches)).rejects.toThrow(
-        BadRequestException,
+        ValidationException,
       );
       await expect(useCase.bulkCreateMatches(userId, matches)).rejects.toThrow(
         'Invalid stage IDs: 1',
       );
     });
 
-    it('should throw BadRequestException when battle type ID is invalid', async () => {
+    it('should throw ValidationException when battle type ID is invalid', async () => {
       const userId = 'test-user-id';
       const matches = [mockMatchData];
 
@@ -216,14 +216,14 @@ describe('MatchUseCase', () => {
       battleTypeRepository.findByIds.mockResolvedValue([]);
 
       await expect(useCase.bulkCreateMatches(userId, matches)).rejects.toThrow(
-        BadRequestException,
+        ValidationException,
       );
       await expect(useCase.bulkCreateMatches(userId, matches)).rejects.toThrow(
         'Invalid battle type IDs: 1',
       );
     });
 
-    it('should throw BadRequestException with multiple errors when multiple IDs are invalid', async () => {
+    it('should throw ValidationException with multiple errors when multiple IDs are invalid', async () => {
       const userId = 'test-user-id';
       const matches = [mockMatchData];
 
@@ -233,7 +233,7 @@ describe('MatchUseCase', () => {
       battleTypeRepository.findByIds.mockResolvedValue([mockBattleType]);
 
       await expect(useCase.bulkCreateMatches(userId, matches)).rejects.toThrow(
-        BadRequestException,
+        ValidationException,
       );
       await expect(useCase.bulkCreateMatches(userId, matches)).rejects.toThrow(
         /Invalid rule IDs: 1.*Invalid weapon IDs: 1/,
@@ -283,7 +283,7 @@ describe('MatchUseCase', () => {
       stageRepository.findByIds.mockResolvedValue([mockStage]);
       battleTypeRepository.findByIds.mockResolvedValue([mockBattleType]);
 
-      await expect(useCase.bulkCreateMatches(userId, matches)).rejects.toThrow(BadRequestException);
+      await expect(useCase.bulkCreateMatches(userId, matches)).rejects.toThrow(ValidationException);
 
       expect(prismaService.$transaction).not.toHaveBeenCalled();
       expect(matchRepository.createMany).not.toHaveBeenCalled();
@@ -398,7 +398,7 @@ describe('MatchUseCase', () => {
       expect(matchRepository.updateOne).toHaveBeenCalled();
     });
 
-    it('should throw BadRequestException when rule ID is invalid', async () => {
+    it('should throw ValidationException when rule ID is invalid', async () => {
       const matches = [mockUpdateMatchData];
 
       ruleRepository.findByIds.mockResolvedValue([]);
@@ -407,7 +407,7 @@ describe('MatchUseCase', () => {
       battleTypeRepository.findByIds.mockResolvedValue([mockBattleType]);
 
       await expect(useCase.bulkUpdateMatches(matches)).rejects.toThrow(
-        BadRequestException,
+        ValidationException,
       );
       await expect(useCase.bulkUpdateMatches(matches)).rejects.toThrow(
         'Invalid rule IDs: 1',
@@ -422,7 +422,7 @@ describe('MatchUseCase', () => {
       stageRepository.findByIds.mockResolvedValue([mockStage]);
       battleTypeRepository.findByIds.mockResolvedValue([mockBattleType]);
 
-      await expect(useCase.bulkUpdateMatches(matches)).rejects.toThrow(BadRequestException);
+      await expect(useCase.bulkUpdateMatches(matches)).rejects.toThrow(ValidationException);
 
       expect(prismaService.$transaction).not.toHaveBeenCalled();
       expect(matchRepository.updateOne).not.toHaveBeenCalled();

--- a/apps/backend/src/match/match.usecase.ts
+++ b/apps/backend/src/match/match.usecase.ts
@@ -1,4 +1,5 @@
-import { Injectable, BadRequestException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { ValidationException } from '../common/exceptions';
 import { PrismaService } from '../prisma/prisma.service';
 import { MatchRepository } from './match.repository';
 import { RuleRepository } from '../rule/rule.repository';
@@ -126,7 +127,7 @@ export class MatchUseCase {
     }
 
     if (errors.length > 0) {
-      throw new BadRequestException(errors.join('; '));
+      throw new ValidationException(errors.join('; '));
     }
   }
 }

--- a/apps/backend/src/user/user.service.spec.ts
+++ b/apps/backend/src/user/user.service.spec.ts
@@ -1,9 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { InternalServerErrorException } from '@nestjs/common';
 import {
-  ConflictException,
-  InternalServerErrorException,
-  NotFoundException,
-} from '@nestjs/common';
+  DuplicateEntityException,
+  EntityNotFoundException,
+} from '../common/exceptions';
 import * as bcrypt from 'bcrypt';
 import { UserSecret } from 'generated/prisma/client';
 import { UserService } from './user.service';
@@ -103,7 +103,7 @@ describe('UserService', () => {
       });
     });
 
-    it('should throw ConflictException if email already exists', async () => {
+    it('should throw DuplicateEntityException if email already exists', async () => {
       const existingUser = {
         id: 'existing-user-id',
         name: 'Existing User',
@@ -115,7 +115,7 @@ describe('UserService', () => {
       repository.findByEmail.mockResolvedValue(existingUser);
 
       await expect(service.createUser(createUser)).rejects.toThrow(
-        ConflictException,
+        DuplicateEntityException,
       );
       await expect(service.createUser(createUser)).rejects.toThrow(
         'Email already exists',
@@ -277,12 +277,12 @@ describe('UserService', () => {
       expect(userUseCase.updateUserWithSecret).toHaveBeenCalled();
     });
 
-    it('should throw NotFoundException if user does not exist', async () => {
+    it('should throw EntityNotFoundException if user does not exist', async () => {
       repository.findById.mockResolvedValue(null);
 
       await expect(
         service.updateUser('non-existent-id', updateUser),
-      ).rejects.toThrow(NotFoundException);
+      ).rejects.toThrow(EntityNotFoundException);
       await expect(
         service.updateUser('non-existent-id', updateUser),
       ).rejects.toThrow('User not found');
@@ -291,7 +291,7 @@ describe('UserService', () => {
       expect(userUseCase.updateUserWithSecret).not.toHaveBeenCalled();
     });
 
-    it('should throw ConflictException if new email already exists', async () => {
+    it('should throw DuplicateEntityException if new email already exists', async () => {
       repository.findById.mockResolvedValue(mockUserWithoutSecret);
       const existingUser = {
         id: 'another-user-id',
@@ -305,7 +305,7 @@ describe('UserService', () => {
 
       await expect(
         service.updateUser('test-user-id', { email: 'taken@example.com' }),
-      ).rejects.toThrow(ConflictException);
+      ).rejects.toThrow(DuplicateEntityException);
       await expect(
         service.updateUser('test-user-id', { email: 'taken@example.com' }),
       ).rejects.toThrow('Email already exists');

--- a/apps/backend/src/user/user.service.ts
+++ b/apps/backend/src/user/user.service.ts
@@ -1,9 +1,8 @@
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import {
-  ConflictException,
-  Injectable,
-  InternalServerErrorException,
-  NotFoundException,
-} from '@nestjs/common';
+  DuplicateEntityException,
+  EntityNotFoundException,
+} from '../common/exceptions';
 import * as bcrypt from 'bcrypt';
 import { CreateUser, UpdateUser, UserResponse } from './user.dto';
 import { UserRepository } from './user.repository';
@@ -19,7 +18,7 @@ export class UserService {
   async createUser(dto: CreateUser): Promise<UserResponse> {
     const existingUser = await this.userRepository.findByEmail(dto.email);
     if (existingUser) {
-      throw new ConflictException('Email already exists');
+      throw new DuplicateEntityException('Email already exists');
     }
 
     const hashedPassword = await bcrypt.hash(dto.password, 10);
@@ -52,13 +51,13 @@ export class UserService {
   async updateUser(userId: string, dto: UpdateUser): Promise<UserResponse> {
     const existingUser = await this.userRepository.findById(userId);
     if (!existingUser) {
-      throw new NotFoundException('User not found');
+      throw new EntityNotFoundException('User not found');
     }
 
     if (dto.email && dto.email !== existingUser.email) {
       const userWithEmail = await this.userRepository.findByEmail(dto.email);
       if (userWithEmail) {
-        throw new ConflictException('Email already exists');
+        throw new DuplicateEntityException('Email already exists');
       }
     }
 


### PR DESCRIPTION
## Summary
- Service/UseCase層からNestJSのHTTP例外クラス (`BadRequestException`, `NotFoundException`, `ForbiddenException`, `UnauthorizedException`, `ConflictException`) への依存を排除
- HTTP非依存なドメイン例外クラスを `src/common/exceptions/` に新設:
  - `EntityNotFoundException` → 404
  - `DuplicateEntityException` → 409
  - `ValidationException` → 400
  - `OwnershipViolationException` → 403
  - `AuthenticationException` → 401
- `DomainExceptionFilter` でドメイン例外をHTTPレスポンスに一括マッピング
- 全テストをドメイン例外に対応するよう更新
- CLAUDE.mdにException Handling Policyを追記

## Motivation
Service/UseCase層がHTTP例外を直接投げるのはレイヤーの責務違反。ビジネスロジック層はHTTPの概念を知るべきではなく、ドメイン固有の例外を投げ、Controller層（またはグローバルフィルター）がHTTPマッピングを担うべき。

## Changes

| File | Change |
|------|--------|
| `common/exceptions/domain.exception.ts` | 5つのドメイン例外クラスを定義 |
| `common/filters/domain-exception.filter.ts` | ドメイン例外→HTTPレスポンスのマッピングフィルター |
| `main.ts` | DomainExceptionFilterをグローバル登録 |
| `analysis.usecase.ts` | `BadRequestException` → `ValidationException` |
| `match.usecase.ts` | `BadRequestException` → `ValidationException` |
| `match.service.ts` | `ForbiddenException` → `OwnershipViolationException` |
| `user.service.ts` | `ConflictException` → `DuplicateEntityException`, `NotFoundException` → `EntityNotFoundException` |
| `auth.service.ts` | `UnauthorizedException` → `AuthenticationException` |
| 全specファイル | ドメイン例外に対応するよう更新 |

## Test plan
- [x] 全128テスト通過 (`pnpm test`)
- [x] DomainExceptionFilter: 6テスト (全マッピング + 未知のサブクラスのフォールバック)
- [ ] 手動: APIリクエストで各種エラーレスポンスのHTTPステータスコードを確認

https://claude.ai/code/session_0189R4UnJTSjymL3x3UEMeDt