### PR TITLE
fix(backend): Prisma Client の生成先を戻して fresh clone でビルドが通るようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@
 - `pnpm prisma migrate reset && pnpm seed:local`
 
 ### 準備
+- `pnpm --filter @app/backend exec prisma generate`
+
+ (Prisma Client を `apps/backend/generated/prisma` に生成します、これがないとビルドが通りません)
+
 - `pnpm run api:generate`
 
  (swaggerの生成とopenapiクライアントの生成をやってくれます、これを実行しないとファイルがいろいろ足りません)

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -80,6 +80,9 @@
     ],
     "rootDir": "src",
     "testRegex": ".*\\.spec\\.ts$",
+    "moduleNameMapper": {
+      "^generated/(.*)$": "<rootDir>/../generated/$1"
+    },
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
   provider = "prisma-client-js"
+  output   = "../generated/prisma"
 }
 
 datasource db {

--- a/apps/backend/src/analysis/analysis.usecase.ts
+++ b/apps/backend/src/analysis/analysis.usecase.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { ValidationException } from '../common/exceptions';
-import { Prisma } from '@prisma/client';
+import { Prisma } from 'generated/prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import {
   GroupByField,

--- a/apps/backend/src/common/filters/prisma-exception.filter.spec.ts
+++ b/apps/backend/src/common/filters/prisma-exception.filter.spec.ts
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client';
+import { Prisma } from 'generated/prisma/client';
 import { PrismaExceptionFilter } from './prisma-exception.filter';
 
 type MockResponse = {

--- a/apps/backend/src/common/filters/prisma-exception.filter.ts
+++ b/apps/backend/src/common/filters/prisma-exception.filter.ts
@@ -1,5 +1,5 @@
 import { ArgumentsHost, Catch, ExceptionFilter } from '@nestjs/common';
-import { Prisma } from '@prisma/client';
+import { Prisma } from 'generated/prisma/client';
 import { Response } from 'express';
 
 @Catch(Prisma.PrismaClientKnownRequestError)

--- a/apps/backend/src/prisma/prisma.service.ts
+++ b/apps/backend/src/prisma/prisma.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient } from 'generated/prisma/client';
 
 @Injectable()
 export class PrismaService

--- a/apps/backend/tsconfig.build.json
+++ b/apps/backend/tsconfig.build.json
@@ -1,6 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  // prisma/ の seed スクリプトは tsx で直接実行するためビルド対象から外す。
-  // 含めると rootDir がパッケージ直下まで広がり、出力が dist/src/main.js になってしまう。
   "exclude": ["node_modules", "test", "dist", "prisma", "**/*spec.ts"]
 }

--- a/apps/backend/tsconfig.build.json
+++ b/apps/backend/tsconfig.build.json
@@ -1,4 +1,6 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  // prisma/ の seed スクリプトは tsx で直接実行するためビルド対象から外す。
+  // 含めると rootDir がパッケージ直下まで広がり、出力が dist/src/main.js になってしまう。
+  "exclude": ["node_modules", "test", "dist", "prisma", "**/*spec.ts"]
 }


### PR DESCRIPTION
スタックPR **1/4**（このPRだけ独立してマージ可能です）

| # | ブランチ | 内容 |
| --- | --- | --- |
| **1** | **`claude/fix-prisma-client-output-path`** | **← このPR。ビルド修正** |
| 2 | `claude/backend-container-and-batch` | 本番イメージ + バッチ入口 |
| 3 | `claude/cdk-infra` | AWS CDK |
| 4 | `claude/analysis-summary-design-doc` | 設計メモ |

## 何が起きていたか

`schema.prisma` の generator に `output` がなく、`prisma generate` がクライアントを `node_modules` に生成していました。そのため `generated/prisma/client` からの import が一切解決できず、**fresh clone では以下の状態でした**。

- `pnpm build` … TS2307 が12件
- `pnpm test` … 17スイート中14スイートが読み込み失敗

手元で動いていたのは、gitignore された `apps/backend/generated/` が過去の生成物として残っていたためです。CI や新しい clone では再現しません。

## 変更内容

- generator の出力先を `../generated/prisma` に指定。各 repository と `prisma/seed.ts` が使っている import パスと一致します
- 残っていた `@prisma/client` からの import 4箇所を同じ生成先パスに統一（カスタム出力先を指定すると `@prisma/client` は初期化済みクライアントを再エクスポートしなくなるため）
- Jest に `moduleNameMapper` を追加。Jest は tsconfig の `baseUrl` を見ないため、これがないと同じく解決できません
- `tsconfig.build.json` から `prisma/` を除外。含まれていると rootDir がパッケージ直下まで広がり、出力が `dist/src/main.js` になってしまいます（`start:prod` は `dist/main` を見ているので現状と噛み合っていませんでした）
- README のセットアップ手順に `prisma generate` を追記

## 確認

- `pnpm build` … 通る
- `pnpm test` … 17スイート / 128テスト すべてパス

---
_Generated by [Claude Code](https://claude.ai/code/session_01CeUN5RZC73bjv4BTU2MP4k)_