### PR TITLE
feat(infra): AWS CDK でアプリと日次バッチのスタックを追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,9 @@
 - UseCase層 複雑なリレーションや複数テーブルを跨ぐためにトランザクションを張る場合などに使用
 - 気持ちとしてはこんな感じ Module > Controller > Service > (UseCase) > Repository
 
+## インフラ
+- AWS CDK 一式は `infra/` にあります → [infra/README.md](infra/README.md)
+- バッチの実行: `pnpm --filter @app/backend batch <jobName>` (例: `smoke`)
+
 ## 生成AI
 - ClaudeCodeにほとんど書かせてます

--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+cdk.out
+*.js
+*.d.ts
+!jest.config.js

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,241 @@
+# infra (AWS CDK)
+
+`re_spla_analysis` の AWS 構成。設計の背景は [docs/analysis-summary-design.md](../docs/analysis-summary-design.md) を参照。
+
+## 構成
+
+```
+                    ┌─────────────┐
+   ユーザー ────────▶│ CloudFront  │──▶ S3 (React ビルド成果物)
+                    └─────────────┘
+                    ┌─────────────┐
+                    │     ALB     │ (public subnet)
+                    └─────────────┘
+                           │
+                    ┌─────────────────────────┐
+                    │ ECS Fargate Service     │ (public subnet, assignPublicIp)
+                    │  api コンテナ            │
+                    └─────────────────────────┘
+                           │
+                    ┌─────────────────────────┐
+                    │ RDS MySQL 8.0           │ (isolated subnet)
+                    └─────────────────────────┘
+                           ▲
+                    ┌─────────────────────────┐
+                    │ ECS Fargate Task (batch)│◀── EventBridge Rule (日次 cron)
+                    └─────────────────────────┘
+```
+
+| スタック | 中身 |
+| --- | --- |
+| `ReSplaAnalysis-<stage>-Network` | VPC / サブネット / セキュリティグループ |
+| `ReSplaAnalysis-<stage>-Registry` | ECR リポジトリ |
+| `ReSplaAnalysis-<stage>-Data` | RDS MySQL / JWT シークレット |
+| `ReSplaAnalysis-<stage>-App` | ECS クラスタ / ALB / API サービス |
+| `ReSplaAnalysis-<stage>-Batch` | バッチ用タスク定義 / EventBridge / 失敗通知 SNS |
+| `ReSplaAnalysis-<stage>-Frontend` | S3 / CloudFront |
+
+### 設計上のポイント
+
+- **NAT Gateway を使わない**。ECS タスクは public subnet にパブリック IP 付きで置き、
+  ECR / CloudWatch Logs / Secrets Manager へは Internet Gateway 経由で到達する。
+  NAT (約 $45/月) と VPC エンドポイント4つ (約 $28/月) をどちらも避けるため。
+  到達制御はセキュリティグループで担保し、RDS は isolated subnet に隔離している。
+- **ALB のセキュリティグループも NetworkStack で作る**。AppStack で作ると
+  「ALB SG (App) → API SG (Network)」の許可ルールがクロススタック参照になり、
+  App → Network の依存と合わせて循環参照でデプロイできなくなる。
+- **API とバッチは同一イメージ**。起動コマンドだけを切り替える。
+- **ヘルスチェック `/health` は DB に触らない**。DB 障害でタスクが延々と入れ替わるのを避けるため。
+- **マイグレーションは CDK のカスタムリソースにしない**。失敗時のリカバリが難しいため、
+  独立した ECS RunTask として明示的に実行する。
+
+## 前提
+
+- AWS CLI v2 / 認証情報 (`aws sts get-caller-identity` が通ること)
+- Docker
+- `pnpm install` 済み
+
+初回のみ CDK bootstrap:
+
+```bash
+pnpm --filter @app/infra exec cdk bootstrap aws://<account-id>/ap-northeast-1
+```
+
+## デプロイ手順
+
+ECS サービスは「イメージが既に push されている」前提で起動するため、順番が重要。
+
+```bash
+export AWS_REGION=ap-northeast-1
+export ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+export ECR=$ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/re-spla-analysis-backend-dev
+export TAG=$(git rev-parse --short HEAD)
+
+# 1. ネットワークと ECR
+pnpm --filter @app/infra exec cdk deploy ReSplaAnalysis-dev-Network ReSplaAnalysis-dev-Registry
+
+# 2. イメージのビルドと push (リポジトリルートで実行)
+aws ecr get-login-password | docker login --username AWS --password-stdin $ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
+docker build --platform linux/amd64 -f apps/backend/Dockerfile -t $ECR:$TAG .
+docker push $ECR:$TAG
+
+# 3. DB / API / バッチ
+pnpm --filter @app/infra exec cdk deploy -c imageTag=$TAG \
+  ReSplaAnalysis-dev-Data ReSplaAnalysis-dev-App ReSplaAnalysis-dev-Batch
+
+# 4. マイグレーションと初期データ投入 (下記「運用コマンド」を参照)
+
+# 5. フロントエンド
+pnpm --filter @app/frontend build
+pnpm --filter @app/infra exec cdk deploy ReSplaAnalysis-dev-Frontend
+```
+
+CloudFront のドメインが確定したら `infra/lib/config.ts` の `api.frontendUrl` に設定して
+App スタックを再デプロイする (CORS の許可オリジン)。
+CloudFront のドメインを AppStack から直接参照すると循環参照になるため、手動で渡す設計にしている。
+
+## 運用コマンド
+
+バッチ用タスク定義は「日次ジョブ / 疎通確認 / マイグレーション」を兼ねる。
+`command` を override して使う。
+
+```bash
+export CLUSTER=$(aws cloudformation describe-stacks --stack-name ReSplaAnalysis-dev-App \
+  --query "Stacks[0].Outputs[?OutputKey=='ClusterName'].OutputValue" --output text)
+export SUBNETS=$(aws ec2 describe-subnets --filters "Name=tag:aws-cdk:subnet-type,Values=Public" \
+  --query 'Subnets[].SubnetId' --output text | tr '\t' ',')
+export SG=$(aws ec2 describe-security-groups \
+  --filters "Name=group-name,Values=*BatchSg*" --query 'SecurityGroups[0].GroupId' --output text)
+export NET="awsvpcConfiguration={subnets=[$SUBNETS],securityGroups=[$SG],assignPublicIp=ENABLED}"
+
+run_batch() {
+  aws ecs run-task --cluster $CLUSTER --launch-type FARGATE \
+    --task-definition re-spla-analysis-dev-batch \
+    --network-configuration "$NET" \
+    --overrides "{\"containerOverrides\":[{\"name\":\"batch\",\"command\":$1}]}"
+}
+
+# マイグレーション
+run_batch '["pnpm","prisma","migrate","deploy"]'
+
+# マスタデータ投入 (ブキ / ステージ / ルールなど)
+run_batch '["pnpm","seed"]'
+
+# 疎通確認 (DB に SELECT 1 するだけ)
+run_batch '["node","dist/batch/main.js","smoke"]'
+```
+
+ログは CloudWatch Logs の `/aws/ecs/...` (BatchLogGroup) に出る。
+
+## 日次バッチを有効にする
+
+`DailyReportRule` は既定で **無効** (`enabled: false`)。
+実ジョブ (`daily-report`) を実装するまで、毎日失敗して通知が飛び続けるのを避けるため。
+
+実装が済んだら `infra/lib/config.ts` の `batch.ruleEnabled` を `true` にして
+Batch スタックを再デプロイする。
+
+```ts
+batch: {
+  ruleEnabled: true,
+  scheduleExpression: 'cron(0 20 * * ? *)', // UTC 20:00 = JST 翌 05:00
+  command: ['node', 'dist/batch/main.js', 'daily-report'],
+}
+```
+
+失敗通知を受け取るには `config.ts` の `alertEmail` を設定する (SNS のメール購読)。
+
+## 使うときだけ立てて壊す運用
+
+このスタックは常時稼働させる前提ではない。**課金はほぼ全部が時間単位なので、
+見たいときに立てて、見終わったら壊すのが一番安い。**
+
+| 稼働時間 | おおよその金額 |
+| --- | --- |
+| 1時間 | $0.09 (約13円) |
+| 半日 (12時間) | $1.1 (約160円) |
+| 1日 | $2.1 (約320円) |
+| 1ヶ月 (730時間) | $64 (約9,600円) |
+
+所要時間の目安:
+
+- `cdk deploy` 一式: **約20分** (RDS 作成が約10分、CloudFront が約5分)
+- `cdk destroy` 一式: **約20分** (CloudFront の無効化＋削除が約15分)
+
+```bash
+# 壊す (依存の逆順。--force で確認プロンプトを省略)
+pnpm --filter @app/infra exec cdk destroy --force \
+  ReSplaAnalysis-dev-Frontend ReSplaAnalysis-dev-Batch ReSplaAnalysis-dev-App \
+  ReSplaAnalysis-dev-Data ReSplaAnalysis-dev-Registry ReSplaAnalysis-dev-Network
+```
+
+dev ステージは RDS / S3 / ECR / ロググループすべて `DESTROY` 設定なので、
+そのまま消える (prod ステージは RETAIN なので残る)。
+
+### destroy 後に残るもの
+
+| 残るもの | 費用 | 対処 |
+| --- | --- | --- |
+| Secrets Manager の3件 (削除待ち状態) | 最大30日間 約$1.2 | すぐ消すなら `aws secretsmanager delete-secret --secret-id <name> --force-delete-without-recovery` |
+| CDK bootstrap スタック (アセット用 S3 / ECR) | 月数セント | 次に使うなら残しておいてよい。消すなら `CDKToolkit` スタックを削除 |
+
+### 消し忘れ対策
+
+立てっぱなしが唯一のリスクなので、AWS Budgets で $5 くらいの閾値アラートを
+1つ作っておくと安心 (無料)。
+
+## コスト目安 (ap-northeast-1, dev ステージ1環境, 730時間/月)
+
+単価は AWS Price List API 実測値 (2026-08 時点)。
+
+| 項目 | 計算 | 月額(USD) |
+| --- | --- | --- |
+| ALB (時間課金) | $0.0243/h × 730 | 17.7 |
+| ALB LCU | 個人利用の低トラフィック想定 | 1〜3 |
+| パブリック IPv4 (ALB, AZ 2つ) | $0.005/h × 2 × 730 | 7.3 |
+| パブリック IPv4 (API タスク) | $0.005/h × 1 × 730 | 3.7 |
+| Fargate vCPU | $0.05056/vCPU-h × 0.25 × 730 | 9.2 |
+| Fargate メモリ | $0.00553/GB-h × 0.5 × 730 | 2.0 |
+| RDS db.t4g.micro Single-AZ | $0.025/h × 730 | 18.3 |
+| RDS gp3 20GB | $0.138/GB-月 × 20 | 2.8 |
+| Secrets Manager (3件) | $0.40 × 3 | 1.2 |
+| ECR (10世代 ≒ 4GB) | $0.10/GB-月 | 0.4 |
+| CloudWatch Logs | 取り込み数百MB 想定 | 0.5 |
+| S3 + CloudFront | CloudFront 無料枠 (1TB/月) 内 | 0.1 |
+| バッチ Fargate (1日1分) | | ≒0 |
+| **合計** | | **約 64 USD (1ドル150円で約9,600円)** |
+
+### 注意
+
+- **パブリック IPv4 の課金 ($0.005/時/アドレス) が約 $11/月ある**。NAT Gateway (約 $45/月) を
+  避けた代償で、それでも NAT より安いが、無視できる額ではない。
+- 固定費がほぼ全額。アクセスが月に数回でも金額はほとんど変わらない。
+- **ALB + Fargate + IPv4 の常時起動分だけで約 $40/月＝全体の6割**。
+- RDS の t 系インスタンスは unlimited モードのため、継続的に高負荷だと CPU クレジット課金が乗る。
+- アカウントが従来の12ヶ月無料利用枠の対象なら RDS db.t4g.micro 750時間/月 + 20GB が無料になり
+  約 $21 減る。2025年以降に作成したアカウントはクレジット方式なので条件が異なる。
+
+### 下げる打ち手 (効果順)
+
+| 手 | 効果 | トレードオフ |
+| --- | --- | --- |
+| ALB をやめて App Runner にする | −$25 (ALB $17.7 + ALB の IPv4 $7.3)、App Runner が +$5〜10 なので **差引 −$15〜20/月** | CDK の App Runner は alpha construct |
+| API を夜間停止 (desiredCount 0 を 8h/日) | −$5/月 | 停止中はアクセス不可 |
+| ログ保持をさらに縮める / ECR 世代を減らす | −$0.5/月 | ほぼ誤差 |
+| Aurora Serverless v2 (min 0 ACU) に置換 | **使い方次第で逆効果**。常時 0.5 ACU 稼働だと $0.15/ACU-h × 0.5 × 730 = **$55/月** で t4g.micro より高い。1日2時間程度しか起動しないなら約 $4.5/月 | レジューム待ち十数秒 |
+
+「毎日ほぼ使う」なら t4g.micro 据え置き、「たまにしか触らない」なら Aurora Serverless v2、
+という分岐になる。最安構成は App Runner + Aurora Serverless v2 (自動停止) で **$15〜25/月**。
+
+## 既知の注意点
+
+- `cdk synth` で `EngineVersion: '8.0' is not one of [...]` という警告が出るが、
+  RDS はメジャーバージョンのみの指定を受け付けるため無視してよい (CFN リンタのリストが古い)。
+- ALB は既定で HTTP:80 リスナーのみ。ACM 証明書がある場合は `config.ts` の
+  `api.certificateArn` を設定すると HTTPS:443 + HTTP からのリダイレクトになる。
+  証明書なしのまま CloudFront (HTTPS) からブラウザ経由で API を叩くと mixed content で
+  ブロックされるため、独自ドメイン + 証明書を用意するか、
+  `frontend.proxyApiThroughCloudFront` を有効にして同一オリジン構成にする
+  (後者はバックエンドに `app.setGlobalPrefix('api')` が必要)。
+- GitHub Actions によるデプロイ自動化はまだ入れていない。手順は上記の手動コマンドと同じで、
+  OIDC で AssumeRole するロールを別途用意する想定。

--- a/infra/bin/app.ts
+++ b/infra/bin/app.ts
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+import * as cdk from "aws-cdk-lib";
+import { AppStack } from "../lib/app-stack";
+import { BatchStack } from "../lib/batch-stack";
+import { getStageConfig } from "../lib/config";
+import { DataStack } from "../lib/data-stack";
+import { FrontendStack } from "../lib/frontend-stack";
+import { NetworkStack } from "../lib/network-stack";
+import { RegistryStack } from "../lib/registry-stack";
+
+const app = new cdk.App();
+
+const stage = String(app.node.tryGetContext("stage") ?? "dev");
+const config = getStageConfig(stage);
+// CI ではコミット SHA を渡す: cdk deploy -c imageTag=$GITHUB_SHA
+const imageTag = String(app.node.tryGetContext("imageTag") ?? "latest");
+
+const env: cdk.Environment = {
+  account: process.env.CDK_DEFAULT_ACCOUNT,
+  region: process.env.CDK_DEFAULT_REGION ?? config.region,
+};
+
+const prefix = `ReSplaAnalysis-${config.stageName}`;
+
+const network = new NetworkStack(app, `${prefix}-Network`, { env, config });
+
+const registry = new RegistryStack(app, `${prefix}-Registry`, { env, config });
+
+const data = new DataStack(app, `${prefix}-Data`, {
+  env,
+  config,
+  vpc: network.vpc,
+  databaseSecurityGroup: network.databaseSecurityGroup,
+});
+
+const appStack = new AppStack(app, `${prefix}-App`, {
+  env,
+  config,
+  imageTag,
+  vpc: network.vpc,
+  albSecurityGroup: network.albSecurityGroup,
+  serviceSecurityGroup: network.serviceSecurityGroup,
+  repository: registry.repository,
+  database: data.database,
+  databaseSecret: data.databaseSecret,
+  jwtSecret: data.jwtSecret,
+  jwtRefreshSecret: data.jwtRefreshSecret,
+});
+
+new BatchStack(app, `${prefix}-Batch`, {
+  env,
+  config,
+  imageTag,
+  vpc: network.vpc,
+  cluster: appStack.cluster,
+  batchSecurityGroup: network.batchSecurityGroup,
+  repository: registry.repository,
+  database: data.database,
+  databaseSecret: data.databaseSecret,
+  jwtSecret: data.jwtSecret,
+  jwtRefreshSecret: data.jwtRefreshSecret,
+});
+
+new FrontendStack(app, `${prefix}-Frontend`, {
+  env,
+  config,
+  apiLoadBalancerDnsName: config.frontend.proxyApiThroughCloudFront
+    ? appStack.loadBalancerDnsName
+    : undefined,
+});
+
+cdk.Tags.of(app).add("Project", "re-spla-analysis");
+cdk.Tags.of(app).add("Stage", config.stageName);

--- a/infra/cdk.json
+++ b/infra/cdk.json
@@ -1,0 +1,15 @@
+{
+  "app": "npx tsx bin/app.ts",
+  "watch": {
+    "include": ["**"],
+    "exclude": ["README.md", "cdk*.json", "node_modules", "cdk.out"]
+  },
+  "output": "cdk.out",
+  "context": {
+    "stage": "dev",
+    "@aws-cdk/core:defaultCrossStackReferences": "strong",
+    "@aws-cdk/aws-ecs:disableEcsImdsBlocking": true,
+    "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true,
+    "@aws-cdk/aws-iam:minimizePolicies": true
+  }
+}

--- a/infra/lib/app-stack.ts
+++ b/infra/lib/app-stack.ts
@@ -1,0 +1,132 @@
+import * as cdk from "aws-cdk-lib";
+import * as acm from "aws-cdk-lib/aws-certificatemanager";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as ecr from "aws-cdk-lib/aws-ecr";
+import * as ecs from "aws-cdk-lib/aws-ecs";
+import * as ecsPatterns from "aws-cdk-lib/aws-ecs-patterns";
+import * as elbv2 from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import * as logs from "aws-cdk-lib/aws-logs";
+import * as rds from "aws-cdk-lib/aws-rds";
+import * as secretsmanager from "aws-cdk-lib/aws-secretsmanager";
+import { Construct } from "constructs";
+import { StageConfig } from "./config";
+import { backendContainerOptions } from "./constructs/backend-container";
+
+export interface AppStackProps extends cdk.StackProps {
+  readonly config: StageConfig;
+  readonly imageTag: string;
+  readonly vpc: ec2.IVpc;
+  readonly albSecurityGroup: ec2.ISecurityGroup;
+  readonly serviceSecurityGroup: ec2.ISecurityGroup;
+  readonly repository: ecr.IRepository;
+  readonly database: rds.DatabaseInstance;
+  readonly databaseSecret: secretsmanager.ISecret;
+  readonly jwtSecret: secretsmanager.ISecret;
+  readonly jwtRefreshSecret: secretsmanager.ISecret;
+}
+
+/**
+ * API 実行環境 (ECS Fargate + ALB)。
+ *
+ * ECS クラスタはバッチからも使うため公開している。
+ */
+export class AppStack extends cdk.Stack {
+  public readonly cluster: ecs.Cluster;
+  public readonly loadBalancerDnsName: string;
+
+  constructor(scope: Construct, id: string, props: AppStackProps) {
+    super(scope, id, props);
+
+    const { config } = props;
+
+    this.cluster = new ecs.Cluster(this, "Cluster", {
+      vpc: props.vpc,
+      // Container Insights は個人利用ではコストに見合わない
+      containerInsightsV2: ecs.ContainerInsights.DISABLED,
+    });
+
+    const logGroup = new logs.LogGroup(this, "ApiLogGroup", {
+      retention: config.logRetention,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+
+    const taskDefinition = new ecs.FargateTaskDefinition(this, "ApiTaskDef", {
+      family: `re-spla-analysis-${config.stageName}-api`,
+      cpu: config.api.cpu,
+      memoryLimitMiB: config.api.memoryLimitMiB,
+      runtimePlatform: {
+        // イメージのビルド環境と揃える。ARM64 にする場合は
+        // docker build --platform linux/arm64 でビルドすること。
+        cpuArchitecture: ecs.CpuArchitecture.X86_64,
+        operatingSystemFamily: ecs.OperatingSystemFamily.LINUX,
+      },
+    });
+
+    taskDefinition.addContainer("api", {
+      ...backendContainerOptions({
+        repository: props.repository,
+        imageTag: props.imageTag,
+        logGroup,
+        streamPrefix: "api",
+        database: props.database,
+        databaseSecret: props.databaseSecret,
+        databaseName: config.database.databaseName,
+        jwtSecret: props.jwtSecret,
+        jwtRefreshSecret: props.jwtRefreshSecret,
+        frontendUrl: config.api.frontendUrl,
+        containerPort: config.api.containerPort,
+      }),
+      portMappings: [{ containerPort: config.api.containerPort }],
+    });
+
+    const certificate = config.api.certificateArn
+      ? acm.Certificate.fromCertificateArn(this, "ApiCertificate", config.api.certificateArn)
+      : undefined;
+
+    // ALB は明示的に作る。L3 パターンに作らせると ALB の SG が AppStack 側に
+    // でき、API タスク SG (NetworkStack) への許可ルールが循環参照になる。
+    const loadBalancer = new elbv2.ApplicationLoadBalancer(this, "ApiAlb", {
+      vpc: props.vpc,
+      internetFacing: true,
+      securityGroup: props.albSecurityGroup,
+      vpcSubnets: { subnetType: ec2.SubnetType.PUBLIC },
+    });
+
+    const service = new ecsPatterns.ApplicationLoadBalancedFargateService(this, "ApiService", {
+      cluster: this.cluster,
+      taskDefinition,
+      desiredCount: config.api.desiredCount,
+      loadBalancer,
+      // NAT Gateway を使わないため、タスク自体を public subnet に置く
+      assignPublicIp: true,
+      taskSubnets: { subnetType: ec2.SubnetType.PUBLIC },
+      securityGroups: [props.serviceSecurityGroup],
+      certificate,
+      listenerPort: certificate ? 443 : 80,
+      redirectHTTP: certificate !== undefined,
+      healthCheckGracePeriod: cdk.Duration.seconds(60),
+      minHealthyPercent: 100,
+      maxHealthyPercent: 200,
+      circuitBreaker: { rollback: true },
+    });
+
+    service.targetGroup.configureHealthCheck({
+      path: "/health",
+      healthyHttpCodes: "200",
+      interval: cdk.Duration.seconds(30),
+      timeout: cdk.Duration.seconds(5),
+      healthyThresholdCount: 2,
+      unhealthyThresholdCount: 3,
+    });
+
+    // タスク入れ替え時に古いタスクの接続を長時間保持しない
+    service.targetGroup.setAttribute("deregistration_delay.timeout_seconds", "30");
+
+    this.loadBalancerDnsName = loadBalancer.loadBalancerDnsName;
+
+    new cdk.CfnOutput(this, "ApiUrl", {
+      value: `${certificate ? "https" : "http"}://${this.loadBalancerDnsName}`,
+    });
+    new cdk.CfnOutput(this, "ClusterName", { value: this.cluster.clusterName });
+  }
+}

--- a/infra/lib/batch-stack.ts
+++ b/infra/lib/batch-stack.ts
@@ -1,0 +1,140 @@
+import * as cdk from "aws-cdk-lib";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as ecr from "aws-cdk-lib/aws-ecr";
+import * as ecs from "aws-cdk-lib/aws-ecs";
+import * as events from "aws-cdk-lib/aws-events";
+import * as targets from "aws-cdk-lib/aws-events-targets";
+import * as logs from "aws-cdk-lib/aws-logs";
+import * as rds from "aws-cdk-lib/aws-rds";
+import * as secretsmanager from "aws-cdk-lib/aws-secretsmanager";
+import * as sns from "aws-cdk-lib/aws-sns";
+import * as subscriptions from "aws-cdk-lib/aws-sns-subscriptions";
+import { Construct } from "constructs";
+import { StageConfig } from "./config";
+import { backendContainerOptions } from "./constructs/backend-container";
+
+export interface BatchStackProps extends cdk.StackProps {
+  readonly config: StageConfig;
+  readonly imageTag: string;
+  readonly vpc: ec2.IVpc;
+  readonly cluster: ecs.ICluster;
+  readonly batchSecurityGroup: ec2.ISecurityGroup;
+  readonly repository: ecr.IRepository;
+  readonly database: rds.DatabaseInstance;
+  readonly databaseSecret: secretsmanager.ISecret;
+  readonly jwtSecret: secretsmanager.ISecret;
+  readonly jwtRefreshSecret: secretsmanager.ISecret;
+}
+
+/**
+ * 日次バッチ (EventBridge -> ECS RunTask)。
+ *
+ * API と同じイメージを使い、command override で起動するジョブを切り替える。
+ * このタスク定義は以下の用途を兼ねる:
+ *   - 日次分析ジョブ   : node dist/batch/main.js daily-report
+ *   - 疎通確認         : node dist/batch/main.js smoke
+ *   - マイグレーション : pnpm prisma migrate deploy
+ */
+export class BatchStack extends cdk.Stack {
+  public readonly taskDefinition: ecs.FargateTaskDefinition;
+  public readonly failureTopic: sns.Topic;
+
+  constructor(scope: Construct, id: string, props: BatchStackProps) {
+    super(scope, id, props);
+
+    const { config } = props;
+    const family = `re-spla-analysis-${config.stageName}-batch`;
+
+    const logGroup = new logs.LogGroup(this, "BatchLogGroup", {
+      retention: config.logRetention,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+
+    this.taskDefinition = new ecs.FargateTaskDefinition(this, "BatchTaskDef", {
+      family,
+      cpu: config.batch.cpu,
+      memoryLimitMiB: config.batch.memoryLimitMiB,
+      runtimePlatform: {
+        cpuArchitecture: ecs.CpuArchitecture.X86_64,
+        operatingSystemFamily: ecs.OperatingSystemFamily.LINUX,
+      },
+    });
+
+    this.taskDefinition.addContainer("batch", {
+      ...backendContainerOptions({
+        repository: props.repository,
+        imageTag: props.imageTag,
+        logGroup,
+        streamPrefix: "batch",
+        database: props.database,
+        databaseSecret: props.databaseSecret,
+        databaseName: config.database.databaseName,
+        jwtSecret: props.jwtSecret,
+        jwtRefreshSecret: props.jwtRefreshSecret,
+        frontendUrl: config.api.frontendUrl,
+        command: config.batch.command,
+      }),
+    });
+
+    new events.Rule(this, "DailyReportRule", {
+      description: "Generate analysis summaries for every user (daily)",
+      // 実ジョブ (daily-report) 実装前は false。config で切り替える。
+      enabled: config.batch.ruleEnabled,
+      schedule: events.Schedule.expression(config.batch.scheduleExpression),
+      targets: [
+        new targets.EcsTask({
+          cluster: props.cluster,
+          taskDefinition: this.taskDefinition,
+          taskCount: 1,
+          assignPublicIp: true,
+          subnetSelection: { subnetType: ec2.SubnetType.PUBLIC },
+          securityGroups: [props.batchSecurityGroup],
+          containerOverrides: [
+            {
+              containerName: "batch",
+              command: config.batch.command,
+            },
+          ],
+          // 失敗はリトライせず通知する (冪等性は upsert で担保するが、
+          // 同じ原因で連続失敗しても通知が増えるだけのため)
+          retryAttempts: 0,
+        }),
+      ],
+    });
+
+    this.failureTopic = new sns.Topic(this, "BatchFailureTopic", {
+      displayName: `re-spla-analysis ${config.stageName} batch failures`,
+    });
+
+    if (config.alertEmail) {
+      this.failureTopic.addSubscription(new subscriptions.EmailSubscription(config.alertEmail));
+    }
+
+    // バッチタスクが 0 以外の終了コードで停止したら通知する。
+    // EventBridge が RunTask するときの group は既定で `family:<family>`。
+    new events.Rule(this, "BatchFailureRule", {
+      description: "Notify when a batch task exits with a non-zero code",
+      eventPattern: {
+        source: ["aws.ecs"],
+        detailType: ["ECS Task State Change"],
+        detail: {
+          clusterArn: [props.cluster.clusterArn],
+          lastStatus: ["STOPPED"],
+          group: [`family:${family}`],
+          containers: {
+            exitCode: [{ "anything-but": [0] }],
+          },
+        },
+      },
+      targets: [
+        new targets.SnsTopic(this.failureTopic, {
+          message: events.RuleTargetInput.fromText(
+            `Batch task failed: ${events.EventField.fromPath("$.detail.taskArn")} (stoppedReason: ${events.EventField.fromPath("$.detail.stoppedReason")})`
+          ),
+        }),
+      ],
+    });
+
+    new cdk.CfnOutput(this, "BatchTaskDefinitionFamily", { value: family });
+  }
+}

--- a/infra/lib/config.ts
+++ b/infra/lib/config.ts
@@ -1,0 +1,129 @@
+import * as cdk from "aws-cdk-lib";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as logs from "aws-cdk-lib/aws-logs";
+
+export type StageName = "dev" | "prod";
+
+export interface StageConfig {
+  readonly stageName: StageName;
+  readonly region: string;
+  readonly vpc: {
+    /** NAT Gateway を使わない構成なので AZ を増やしてもコストは増えない */
+    readonly maxAzs: number;
+  };
+  readonly database: {
+    readonly instanceSize: ec2.InstanceSize;
+    readonly allocatedStorageGb: number;
+    readonly backupRetentionDays: number;
+    readonly deletionProtection: boolean;
+    readonly removalPolicy: cdk.RemovalPolicy;
+    readonly databaseName: string;
+  };
+  readonly registry: {
+    /** dev は使い捨て前提。RETAIN にするとイメージが残り cdk destroy が失敗する */
+    readonly removalPolicy: cdk.RemovalPolicy;
+  };
+  readonly api: {
+    readonly cpu: number;
+    readonly memoryLimitMiB: number;
+    readonly desiredCount: number;
+    readonly containerPort: number;
+    /**
+     * CORS 許可オリジン。CloudFront のドメインは AppStack から参照すると
+     * 循環参照になるため、初回デプロイ後に確定した値をここに書く。
+     */
+    readonly frontendUrl: string;
+    /** ACM 証明書 (ap-northeast-1) がある場合のみ HTTPS リスナーを作る */
+    readonly certificateArn?: string;
+  };
+  readonly batch: {
+    /**
+     * 実際の分析ジョブ (daily-report) を実装するまでは false。
+     * 未実装のジョブを毎日叩いて失敗通知が飛び続けるのを避けるため。
+     */
+    readonly ruleEnabled: boolean;
+    /** EventBridge の cron は UTC 固定。JST 5:00 = UTC 20:00 */
+    readonly scheduleExpression: string;
+    readonly command: string[];
+    readonly cpu: number;
+    readonly memoryLimitMiB: number;
+  };
+  readonly frontend: {
+    /**
+     * true にすると CloudFront の /api/* を ALB に流す (同一オリジン構成)。
+     * バックエンド側に app.setGlobalPrefix('api') が必要なので既定は false。
+     */
+    readonly proxyApiThroughCloudFront: boolean;
+    readonly removalPolicy: cdk.RemovalPolicy;
+    readonly autoDeleteObjects: boolean;
+  };
+  readonly logRetention: logs.RetentionDays;
+  /** 指定するとバッチ失敗時に SNS からメールが飛ぶ */
+  readonly alertEmail?: string;
+}
+
+const dev: StageConfig = {
+  stageName: "dev",
+  region: "ap-northeast-1",
+  vpc: { maxAzs: 2 },
+  database: {
+    instanceSize: ec2.InstanceSize.MICRO,
+    allocatedStorageGb: 20,
+    backupRetentionDays: 1,
+    deletionProtection: false,
+    removalPolicy: cdk.RemovalPolicy.DESTROY,
+    databaseName: "re_spla_analysis_db",
+  },
+  registry: { removalPolicy: cdk.RemovalPolicy.DESTROY },
+  api: {
+    cpu: 256,
+    memoryLimitMiB: 512,
+    desiredCount: 1,
+    containerPort: 3000,
+    frontendUrl: "http://localhost:5173",
+  },
+  batch: {
+    ruleEnabled: false,
+    scheduleExpression: "cron(0 20 * * ? *)",
+    command: ["node", "dist/batch/main.js", "daily-report"],
+    cpu: 256,
+    memoryLimitMiB: 512,
+  },
+  frontend: {
+    proxyApiThroughCloudFront: false,
+    removalPolicy: cdk.RemovalPolicy.DESTROY,
+    autoDeleteObjects: true,
+  },
+  logRetention: logs.RetentionDays.ONE_WEEK,
+};
+
+const prod: StageConfig = {
+  ...dev,
+  stageName: "prod",
+  registry: { removalPolicy: cdk.RemovalPolicy.RETAIN },
+  database: {
+    ...dev.database,
+    backupRetentionDays: 7,
+    deletionProtection: true,
+    removalPolicy: cdk.RemovalPolicy.RETAIN,
+  },
+  frontend: {
+    proxyApiThroughCloudFront: false,
+    removalPolicy: cdk.RemovalPolicy.RETAIN,
+    autoDeleteObjects: false,
+  },
+  logRetention: logs.RetentionDays.TWO_WEEKS,
+};
+
+const configs: Record<StageName, StageConfig> = { dev, prod };
+
+export function isStageName(value: string): value is StageName {
+  return value === "dev" || value === "prod";
+}
+
+export function getStageConfig(stage: string): StageConfig {
+  if (!isStageName(stage)) {
+    throw new Error(`Unknown stage: ${stage}. Use -c stage=dev or -c stage=prod.`);
+  }
+  return configs[stage];
+}

--- a/infra/lib/constructs/backend-container.ts
+++ b/infra/lib/constructs/backend-container.ts
@@ -1,0 +1,55 @@
+import * as ecr from "aws-cdk-lib/aws-ecr";
+import * as ecs from "aws-cdk-lib/aws-ecs";
+import * as logs from "aws-cdk-lib/aws-logs";
+import * as rds from "aws-cdk-lib/aws-rds";
+import * as secretsmanager from "aws-cdk-lib/aws-secretsmanager";
+
+export interface BackendContainerOptionsProps {
+  readonly repository: ecr.IRepository;
+  readonly imageTag: string;
+  readonly logGroup: logs.ILogGroup;
+  readonly streamPrefix: string;
+  readonly database: rds.DatabaseInstance;
+  readonly databaseSecret: secretsmanager.ISecret;
+  readonly databaseName: string;
+  readonly jwtSecret: secretsmanager.ISecret;
+  readonly jwtRefreshSecret: secretsmanager.ISecret;
+  readonly frontendUrl: string;
+  readonly containerPort?: number;
+  readonly command?: string[];
+}
+
+/**
+ * API とバッチで同一イメージ・同一の環境変数を使うため、コンテナ定義を共通化する。
+ *
+ * DATABASE_URL をそのまま渡さず DB_* に分けているのは、Secrets Manager が返す
+ * のがユーザー名とパスワードの個別値であり、接続 URL を CloudFormation 側で
+ * 組み立てるとパスワードがテンプレートに露出しうるため。
+ * URL への組み立てはコンテナの docker-entrypoint.sh が行う。
+ */
+export function backendContainerOptions(
+  props: BackendContainerOptionsProps
+): ecs.ContainerDefinitionOptions {
+  return {
+    image: ecs.ContainerImage.fromEcrRepository(props.repository, props.imageTag),
+    command: props.command,
+    logging: ecs.LogDrivers.awsLogs({
+      logGroup: props.logGroup,
+      streamPrefix: props.streamPrefix,
+    }),
+    environment: {
+      NODE_ENV: "production",
+      PORT: String(props.containerPort ?? 3000),
+      DB_HOST: props.database.instanceEndpoint.hostname,
+      DB_PORT: String(props.database.instanceEndpoint.port),
+      DB_NAME: props.databaseName,
+      FRONTEND_URL: props.frontendUrl,
+    },
+    secrets: {
+      DB_USER: ecs.Secret.fromSecretsManager(props.databaseSecret, "username"),
+      DB_PASSWORD: ecs.Secret.fromSecretsManager(props.databaseSecret, "password"),
+      JWT_SECRET: ecs.Secret.fromSecretsManager(props.jwtSecret),
+      JWT_REFRESH_SECRET: ecs.Secret.fromSecretsManager(props.jwtRefreshSecret),
+    },
+  };
+}

--- a/infra/lib/data-stack.ts
+++ b/infra/lib/data-stack.ts
@@ -1,0 +1,96 @@
+import * as cdk from "aws-cdk-lib";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as rds from "aws-cdk-lib/aws-rds";
+import * as secretsmanager from "aws-cdk-lib/aws-secretsmanager";
+import { Construct } from "constructs";
+import { StageConfig } from "./config";
+
+export interface DataStackProps extends cdk.StackProps {
+  readonly config: StageConfig;
+  readonly vpc: ec2.IVpc;
+  readonly databaseSecurityGroup: ec2.ISecurityGroup;
+}
+
+/**
+ * RDS とアプリケーションシークレット。
+ *
+ * DATABASE_URL は接続情報を URL に組み立てる必要があるが、Secrets Manager の
+ * 自動生成パスワードを URL に埋める都合上、記号を除外して生成している
+ * (コンテナ側の docker-entrypoint.sh で URL エンコードせずに連結するため)。
+ */
+export class DataStack extends cdk.Stack {
+  public readonly database: rds.DatabaseInstance;
+  public readonly databaseSecret: secretsmanager.ISecret;
+  public readonly jwtSecret: secretsmanager.Secret;
+  public readonly jwtRefreshSecret: secretsmanager.Secret;
+
+  constructor(scope: Construct, id: string, props: DataStackProps) {
+    super(scope, id, props);
+
+    const { config } = props;
+
+    // URL に埋め込んでも壊れない文字だけでパスワードを生成する
+    const excludeCharacters = " %+~`#$&*()|[]{}:;<>?!'/@\"\\,^-=";
+
+    this.database = new rds.DatabaseInstance(this, "Database", {
+      engine: rds.DatabaseInstanceEngine.mysql({
+        // マイナーバージョンは自動アップグレードに任せるため major のみ指定する。
+        // cdk synth が "EngineVersion: '8.0' is not one of [...]" と警告するが、
+        // RDS はメジャーのみの指定を受け付けるため無視してよい。
+        version: rds.MysqlEngineVersion.VER_8_0,
+      }),
+      instanceType: ec2.InstanceType.of(
+        ec2.InstanceClass.BURSTABLE4_GRAVITON,
+        config.database.instanceSize
+      ),
+      vpc: props.vpc,
+      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_ISOLATED },
+      securityGroups: [props.databaseSecurityGroup],
+      credentials: rds.Credentials.fromGeneratedSecret("admin", {
+        excludeCharacters,
+      }),
+      databaseName: config.database.databaseName,
+      allocatedStorage: config.database.allocatedStorageGb,
+      storageType: rds.StorageType.GP3,
+      storageEncrypted: true,
+      multiAz: false,
+      publiclyAccessible: false,
+      autoMinorVersionUpgrade: true,
+      allowMajorVersionUpgrade: false,
+      backupRetention: cdk.Duration.days(config.database.backupRetentionDays),
+      deleteAutomatedBackups: config.stageName !== "prod",
+      deletionProtection: config.database.deletionProtection,
+      removalPolicy: config.database.removalPolicy,
+      // 個人利用ではコストに見合わないため無効
+      enablePerformanceInsights: false,
+    });
+
+    if (!this.database.secret) {
+      throw new Error("Database secret was not generated");
+    }
+    this.databaseSecret = this.database.secret;
+
+    this.jwtSecret = new secretsmanager.Secret(this, "JwtSecret", {
+      description: "JWT access token signing key",
+      generateSecretString: {
+        passwordLength: 64,
+        excludePunctuation: true,
+      },
+    });
+
+    this.jwtRefreshSecret = new secretsmanager.Secret(this, "JwtRefreshSecret", {
+      description: "JWT refresh token signing key",
+      generateSecretString: {
+        passwordLength: 64,
+        excludePunctuation: true,
+      },
+    });
+
+    new cdk.CfnOutput(this, "DatabaseEndpoint", {
+      value: this.database.instanceEndpoint.hostname,
+    });
+    new cdk.CfnOutput(this, "DatabaseSecretName", {
+      value: this.databaseSecret.secretName,
+    });
+  }
+}

--- a/infra/lib/frontend-stack.ts
+++ b/infra/lib/frontend-stack.ts
@@ -1,0 +1,108 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as cdk from "aws-cdk-lib";
+import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
+import * as origins from "aws-cdk-lib/aws-cloudfront-origins";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as s3deploy from "aws-cdk-lib/aws-s3-deployment";
+import { Construct } from "constructs";
+import { StageConfig } from "./config";
+
+export interface FrontendStackProps extends cdk.StackProps {
+  readonly config: StageConfig;
+  /** config.frontend.proxyApiThroughCloudFront が true のときのみ渡す */
+  readonly apiLoadBalancerDnsName?: string;
+}
+
+/**
+ * フロントエンド配信 (S3 + CloudFront)。
+ *
+ * ビルド成果物 (apps/frontend/dist) が存在するときだけ BucketDeployment を作る。
+ * インフラだけを synth / diff したいときにフロントのビルドを強制しないため。
+ */
+export class FrontendStack extends cdk.Stack {
+  public readonly distributionDomainName: string;
+
+  constructor(scope: Construct, id: string, props: FrontendStackProps) {
+    super(scope, id, props);
+
+    const { config } = props;
+
+    const bucket = new s3.Bucket(this, "SiteBucket", {
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      enforceSSL: true,
+      removalPolicy: config.frontend.removalPolicy,
+      autoDeleteObjects: config.frontend.autoDeleteObjects,
+    });
+
+    const distribution = new cloudfront.Distribution(this, "Distribution", {
+      defaultRootObject: "index.html",
+      defaultBehavior: {
+        origin: origins.S3BucketOrigin.withOriginAccessControl(bucket),
+        viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+        cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+      },
+      // SPA なので存在しないパスは index.html に寄せる
+      errorResponses: [
+        {
+          httpStatus: 403,
+          responseHttpStatus: 200,
+          responsePagePath: "/index.html",
+          ttl: cdk.Duration.minutes(5),
+        },
+        {
+          httpStatus: 404,
+          responseHttpStatus: 200,
+          responsePagePath: "/index.html",
+          ttl: cdk.Duration.minutes(5),
+        },
+      ],
+      // 日本を含むエッジロケーションを使う
+      priceClass: cloudfront.PriceClass.PRICE_CLASS_200,
+    });
+
+    if (config.frontend.proxyApiThroughCloudFront) {
+      if (!props.apiLoadBalancerDnsName) {
+        throw new Error(
+          "apiLoadBalancerDnsName is required when proxyApiThroughCloudFront is enabled"
+        );
+      }
+
+      // 同一オリジン構成。バックエンドに app.setGlobalPrefix('api') が必要。
+      distribution.addBehavior(
+        "/api/*",
+        new origins.HttpOrigin(props.apiLoadBalancerDnsName, {
+          protocolPolicy: cloudfront.OriginProtocolPolicy.HTTP_ONLY,
+        }),
+        {
+          viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+          allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
+          cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
+          originRequestPolicy: cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+        }
+      );
+    }
+
+    const distDir = path.resolve(__dirname, "../../apps/frontend/dist");
+    if (fs.existsSync(distDir)) {
+      new s3deploy.BucketDeployment(this, "DeploySite", {
+        sources: [s3deploy.Source.asset(distDir)],
+        destinationBucket: bucket,
+        distribution,
+        distributionPaths: ["/*"],
+      });
+    } else {
+      cdk.Annotations.of(this).addInfo(
+        `apps/frontend/dist not found; skipping BucketDeployment. Run "pnpm --filter @app/frontend build" before deploying.`
+      );
+    }
+
+    this.distributionDomainName = distribution.distributionDomainName;
+
+    new cdk.CfnOutput(this, "SiteUrl", {
+      value: `https://${distribution.distributionDomainName}`,
+    });
+    new cdk.CfnOutput(this, "SiteBucketName", { value: bucket.bucketName });
+  }
+}

--- a/infra/lib/network-stack.ts
+++ b/infra/lib/network-stack.ts
@@ -1,0 +1,99 @@
+import * as cdk from "aws-cdk-lib";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import { Construct } from "constructs";
+import { StageConfig } from "./config";
+
+export interface NetworkStackProps extends cdk.StackProps {
+  readonly config: StageConfig;
+}
+
+/**
+ * VPC とセキュリティグループ。
+ *
+ * NAT Gateway (約 $45/月) を避けるため、ECS タスクは public subnet に
+ * パブリック IP 付きで置き、ECR / CloudWatch Logs / Secrets Manager へは
+ * Internet Gateway 経由で到達する。DB だけを isolated subnet に隔離し、
+ * 到達制御はセキュリティグループで行う。
+ *
+ * private subnet + VPC エンドポイント構成は interface 型を4つ張ると
+ * 約 $28/月かかり、個人規模では NAT を避ける旨みが薄いため採用していない。
+ */
+export class NetworkStack extends cdk.Stack {
+  public readonly vpc: ec2.Vpc;
+  public readonly albSecurityGroup: ec2.SecurityGroup;
+  public readonly serviceSecurityGroup: ec2.SecurityGroup;
+  public readonly batchSecurityGroup: ec2.SecurityGroup;
+  public readonly databaseSecurityGroup: ec2.SecurityGroup;
+
+  constructor(scope: Construct, id: string, props: NetworkStackProps) {
+    super(scope, id, props);
+
+    this.vpc = new ec2.Vpc(this, "Vpc", {
+      maxAzs: props.config.vpc.maxAzs,
+      natGateways: 0,
+      subnetConfiguration: [
+        {
+          name: "public",
+          subnetType: ec2.SubnetType.PUBLIC,
+          cidrMask: 24,
+        },
+        {
+          name: "isolated",
+          subnetType: ec2.SubnetType.PRIVATE_ISOLATED,
+          cidrMask: 24,
+        },
+      ],
+      restrictDefaultSecurityGroup: true,
+    });
+
+    // ALB の SG も AppStack ではなくここで作る。
+    // AppStack 側で作ると「ALB SG (App) -> API SG (Network)」の許可ルールが
+    // クロススタック参照になり、App -> Network の依存と合わせて循環参照になる。
+    this.albSecurityGroup = new ec2.SecurityGroup(this, "AlbSg", {
+      vpc: this.vpc,
+      description: "Public ALB for the API",
+      allowAllOutbound: true,
+    });
+    this.albSecurityGroup.addIngressRule(
+      ec2.Peer.anyIpv4(),
+      ec2.Port.tcp(80),
+      "HTTP from anywhere"
+    );
+    this.albSecurityGroup.addIngressRule(
+      ec2.Peer.anyIpv4(),
+      ec2.Port.tcp(443),
+      "HTTPS from anywhere"
+    );
+
+    this.serviceSecurityGroup = new ec2.SecurityGroup(this, "ServiceSg", {
+      vpc: this.vpc,
+      description: "ECS service (API) tasks",
+      allowAllOutbound: true,
+    });
+
+    this.batchSecurityGroup = new ec2.SecurityGroup(this, "BatchSg", {
+      vpc: this.vpc,
+      description: "ECS batch tasks",
+      allowAllOutbound: true,
+    });
+
+    this.databaseSecurityGroup = new ec2.SecurityGroup(this, "DatabaseSg", {
+      vpc: this.vpc,
+      description: "RDS MySQL",
+      allowAllOutbound: false,
+    });
+
+    // DB へのインバウンドは API タスクとバッチタスクからのみ。
+    // ALB -> API のインバウンドは AppStack 側 (ALB 作成時) で追加される。
+    this.databaseSecurityGroup.addIngressRule(
+      this.serviceSecurityGroup,
+      ec2.Port.tcp(3306),
+      "API tasks"
+    );
+    this.databaseSecurityGroup.addIngressRule(
+      this.batchSecurityGroup,
+      ec2.Port.tcp(3306),
+      "Batch tasks"
+    );
+  }
+}

--- a/infra/lib/registry-stack.ts
+++ b/infra/lib/registry-stack.ts
@@ -1,0 +1,45 @@
+import * as cdk from "aws-cdk-lib";
+import * as ecr from "aws-cdk-lib/aws-ecr";
+import { Construct } from "constructs";
+import { StageConfig } from "./config";
+
+export interface RegistryStackProps extends cdk.StackProps {
+  readonly config: StageConfig;
+}
+
+/**
+ * ECR リポジトリ。
+ *
+ * ECS サービスは「イメージが既に push されている」ことを前提に起動するため、
+ * AppStack とは分けて先にデプロイできるようにしている。
+ * デプロイ順: Network -> Registry -> (イメージ push) -> Data -> App -> Batch -> Frontend
+ */
+export class RegistryStack extends cdk.Stack {
+  public readonly repository: ecr.Repository;
+
+  constructor(scope: Construct, id: string, props: RegistryStackProps) {
+    super(scope, id, props);
+
+    const destroyable = props.config.registry.removalPolicy === cdk.RemovalPolicy.DESTROY;
+
+    this.repository = new ecr.Repository(this, "BackendRepository", {
+      repositoryName: `re-spla-analysis-backend-${props.config.stageName}`,
+      imageScanOnPush: true,
+      imageTagMutability: ecr.TagMutability.MUTABLE,
+      removalPolicy: props.config.registry.removalPolicy,
+      // イメージが残っているリポジトリは削除できず cdk destroy が失敗するため、
+      // 使い捨て前提のステージでは中身ごと消す
+      emptyOnDelete: destroyable,
+      lifecycleRules: [
+        {
+          description: "Keep only the latest 10 images",
+          maxImageCount: 10,
+        },
+      ],
+    });
+
+    new cdk.CfnOutput(this, "RepositoryUri", {
+      value: this.repository.repositoryUri,
+    });
+  }
+}

--- a/infra/package.json
+++ b/infra/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@app/infra",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "build": "tsc --noEmit",
+    "lint": "tsc --noEmit",
+    "synth": "cdk synth",
+    "diff": "cdk diff",
+    "deploy": "cdk deploy",
+    "destroy": "cdk destroy",
+    "format": "prettier --write \"bin/**/*.ts\" \"lib/**/*.ts\""
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.219.0",
+    "constructs": "^10.4.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.18.13",
+    "aws-cdk": "^2.1031.0",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  }
+}

--- a/infra/tsconfig.json
+++ b/infra/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "lib": ["ES2022"],
+    "declaration": false,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "typeRoots": ["./node_modules/@types"]
+  },
+  "include": ["bin/**/*.ts", "lib/**/*.ts"],
+  "exclude": ["node_modules", "cdk.out"]
+}

--- a/infra/turbo.json
+++ b/infra/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": []
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,6 +248,28 @@ importers:
         specifier: ^7.1.7
         version: 7.1.12(@types/node@24.9.2)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.6)
 
+  infra:
+    dependencies:
+      aws-cdk-lib:
+        specifier: ^2.219.0
+        version: 2.266.0(constructs@10.8.1)
+      constructs:
+        specifier: ^10.4.2
+        version: 10.8.1
+    devDependencies:
+      '@types/node':
+        specifier: ^22.18.13
+        version: 22.18.13
+      aws-cdk:
+        specifier: ^2.1031.0
+        version: 2.1138.0
+      tsx:
+        specifier: ^4.20.6
+        version: 4.20.6
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
 packages:
 
   '@angular-devkit/core@19.2.15':
@@ -318,6 +340,19 @@ packages:
   '@apidevtools/json-schema-ref-parser@11.9.3':
     resolution: {integrity: sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==}
     engines: {node: '>= 16'}
+
+  '@aws-cdk/asset-awscli-v1@2.2.292':
+    resolution: {integrity: sha512-d4aMFsAFj19FtxVyw8IzlUKv5Zu4sIvgnEjI2IU6IWBJgVbJ4aFnadANqYa+6MwB1CQbGOg0jh8WE77M+Nb/9A==}
+
+  '@aws-cdk/asset-node-proxy-agent-v6@2.1.2':
+    resolution: {integrity: sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==}
+
+  '@aws-cdk/cloud-assembly-schema@54.20.0':
+    resolution: {integrity: sha512-ts2dVBi0VUXOLKcqyLYsHUWYpwGPFd+xm4q+6Y4jjP8orwodjRi2mJrmpy9b0gHnbv8e/hFnmEbqrD0bBJOnPA==}
+    engines: {node: '>= 18.0.0'}
+    bundledDependencies:
+      - jsonschema
+      - semver
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -2128,6 +2163,30 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  aws-cdk-lib@2.266.0:
+    resolution: {integrity: sha512-sBQU42pEc9ud3yeVU2En2euQRUhCg63eaJIPEVpBtE5aPhJjN3d9MkzQ9eYGLVXP3fnohUE54BiVOdUrkEDUbg==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      constructs: ^10.5.0
+    bundledDependencies:
+      - '@aws/cloudformation-validate'
+      - '@balena/dockerignore'
+      - '@aws-cdk/cloud-assembly-api'
+      - case
+      - fs-extra
+      - ignore
+      - jsonschema
+      - minimatch
+      - punycode
+      - semver
+      - yaml
+      - mime-types
+
+  aws-cdk@2.1138.0:
+    resolution: {integrity: sha512-gZ5F8rmh+qc7ZNWsbaXYoV+p7jSYynRRg70s7FAn3VmzRaSkTE31ijpQHYroxCbDEtKSzgN63ORR/WuZmvXAwA==}
+    engines: {node: '>= 18.0.0'}
+    hasBin: true
+
   axios@1.13.2:
     resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
 
@@ -2369,6 +2428,9 @@ packages:
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
+
+  constructs@10.8.1:
+    resolution: {integrity: sha512-98yGXYyhePqPYh3cYu8nzBERmAhC0DONe3UD03okK0nehZ7hYP4wgZuf02a04+uOWxnTJ5Rpp5m0GRNpwyLGGA==}
 
   content-disposition@1.0.0:
     resolution: {integrity: sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==}
@@ -4577,6 +4639,12 @@ snapshots:
       '@types/json-schema': 7.0.15
       js-yaml: 4.1.1
 
+  '@aws-cdk/asset-awscli-v1@2.2.292': {}
+
+  '@aws-cdk/asset-node-proxy-agent-v6@2.1.2': {}
+
+  '@aws-cdk/cloud-assembly-schema@54.20.0': {}
+
   '@babel/code-frame@7.27.1':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -5115,7 +5183,7 @@ snapshots:
   '@jest/console@30.2.0':
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 22.18.13
+      '@types/node': 24.9.2
       chalk: 4.1.2
       jest-message-util: 30.2.0
       jest-util: 30.2.0
@@ -5129,14 +5197,14 @@ snapshots:
       '@jest/test-result': 30.2.0
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 22.18.13
+      '@types/node': 24.9.2
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.3.1
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.2.0
-      jest-config: 30.2.0(@types/node@22.18.13)(ts-node@10.9.2(@types/node@22.18.13)(typescript@5.9.3))
+      jest-config: 30.2.0(@types/node@24.9.2)(ts-node@10.9.2(@types/node@22.18.13)(typescript@5.9.3))
       jest-haste-map: 30.2.0
       jest-message-util: 30.2.0
       jest-regex-util: 30.0.1
@@ -5199,7 +5267,7 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 22.18.13
+      '@types/node': 24.9.2
       jest-regex-util: 30.0.1
 
   '@jest/reporters@30.2.0':
@@ -5210,7 +5278,7 @@ snapshots:
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 22.18.13
+      '@types/node': 24.9.2
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit-x: 0.2.2
@@ -5287,7 +5355,7 @@ snapshots:
       '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.18.13
+      '@types/node': 24.9.2
       '@types/yargs': 17.0.34
       chalk: 4.1.2
 
@@ -6051,11 +6119,11 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.18.13
+      '@types/node': 24.9.2
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.18.13
+      '@types/node': 24.9.2
 
   '@types/cookie-parser@1.4.10(@types/express@5.0.5)':
     dependencies:
@@ -6077,7 +6145,7 @@ snapshots:
 
   '@types/express-serve-static-core@5.1.0':
     dependencies:
-      '@types/node': 22.18.13
+      '@types/node': 24.9.2
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -6155,16 +6223,16 @@ snapshots:
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 22.18.13
+      '@types/node': 24.9.2
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 22.18.13
+      '@types/node': 24.9.2
 
   '@types/serve-static@1.15.10':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 22.18.13
+      '@types/node': 24.9.2
       '@types/send': 0.17.6
 
   '@types/stack-utils@2.0.3': {}
@@ -6173,7 +6241,7 @@ snapshots:
     dependencies:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
-      '@types/node': 22.18.13
+      '@types/node': 24.9.2
       form-data: 4.0.4
 
   '@types/supertest@6.0.3':
@@ -6582,6 +6650,15 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  aws-cdk-lib@2.266.0(constructs@10.8.1):
+    dependencies:
+      '@aws-cdk/asset-awscli-v1': 2.2.292
+      '@aws-cdk/asset-node-proxy-agent-v6': 2.1.2
+      '@aws-cdk/cloud-assembly-schema': 54.20.0
+      constructs: 10.8.1
+
+  aws-cdk@2.1138.0: {}
+
   axios@1.13.2:
     dependencies:
       follow-redirects: 1.15.11
@@ -6853,6 +6930,8 @@ snapshots:
   confbox@0.2.2: {}
 
   consola@3.4.2: {}
+
+  constructs@10.8.1: {}
 
   content-disposition@1.0.0:
     dependencies:
@@ -7665,6 +7744,39 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-config@30.2.0(@types/node@24.9.2)(ts-node@10.9.2(@types/node@22.18.13)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.28.5
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.0.1
+      '@jest/test-sequencer': 30.2.0
+      '@jest/types': 30.2.0
+      babel-jest: 30.2.0(@babel/core@7.28.5)
+      chalk: 4.1.2
+      ci-info: 4.3.1
+      deepmerge: 4.3.1
+      glob: 10.4.5
+      graceful-fs: 4.2.11
+      jest-circus: 30.2.0
+      jest-docblock: 30.2.0
+      jest-environment-node: 30.2.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.2.0
+      jest-runner: 30.2.0
+      jest-util: 30.2.0
+      jest-validate: 30.2.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 30.2.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 24.9.2
+      ts-node: 10.9.2(@types/node@22.18.13)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
   jest-diff@30.2.0:
     dependencies:
       '@jest/diff-sequences': 30.0.1
@@ -7697,7 +7809,7 @@ snapshots:
   jest-haste-map@30.2.0:
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 22.18.13
+      '@types/node': 24.9.2
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -7736,7 +7848,7 @@ snapshots:
   jest-mock@30.2.0:
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 22.18.13
+      '@types/node': 24.9.2
       jest-util: 30.2.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@30.2.0):
@@ -7770,7 +7882,7 @@ snapshots:
       '@jest/test-result': 30.2.0
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 22.18.13
+      '@types/node': 24.9.2
       chalk: 4.1.2
       emittery: 0.13.1
       exit-x: 0.2.2
@@ -7799,7 +7911,7 @@ snapshots:
       '@jest/test-result': 30.2.0
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 22.18.13
+      '@types/node': 24.9.2
       chalk: 4.1.2
       cjs-module-lexer: 2.1.0
       collect-v8-coverage: 1.0.3
@@ -7846,7 +7958,7 @@ snapshots:
   jest-util@30.2.0:
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 22.18.13
+      '@types/node': 24.9.2
       chalk: 4.1.2
       ci-info: 4.3.1
       graceful-fs: 4.2.11
@@ -7865,7 +7977,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 22.18.13
+      '@types/node': 24.9.2
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - "apps/*"
   - "packages/*"
+  - "infra"


### PR DESCRIPTION
スタックPR **3/4**（base は #36）

| # | ブランチ | 内容 |
| --- | --- | --- |
| 1 | `claude/fix-prisma-client-output-path` | ビルド修正 (#35) |
| 2 | `claude/backend-container-and-batch` | 本番イメージ + バッチ入口 (#36) |
| **3** | **`claude/cdk-infra`** | **← このPR。AWS CDK** |
| 4 | `claude/analysis-summary-design-doc` | 設計メモ |

`infra/` に CDK アプリを追加します。**まだ AWS アカウントには一切デプロイしていません。**

## スタック構成

デプロイ順: `Network → Registry →（イメージ push）→ Data → App → Batch → Frontend`

| スタック | 中身 |
| --- | --- |
| Network | VPC / サブネット / セキュリティグループ |
| Registry | ECR |
| Data | RDS MySQL 8.0 / JWTシークレット |
| App | ECS クラスタ / ALB / API サービス |
| Batch | バッチ用タスク定義 / EventBridge / 失敗通知SNS |
| Frontend | S3 / CloudFront |

## レビューで見てほしい判断ポイント

- **NAT Gateway を使っていません**。ECS タスクを public subnet にパブリックIP付きで置き、RDS だけ isolated subnet に隔離してSGで制御しています。NAT（約$45/月）も VPCエンドポイント4つ（約$28/月）も避けられますが、代わりに**パブリックIPv4の課金が約$11/月**かかります
- **ALB のセキュリティグループを NetworkStack に置いています**。AppStack で作ると「ALB SG(App) → API SG(Network)」の許可ルールがクロススタック参照になり、App→Network の依存と合わせて**循環参照で synth が落ちます**（実際に踏みました）
- **シークレットは Secrets Manager**。当初 SSM Parameter Store を想定しましたが、CloudFormation は SecureString パラメータを作成できません
- **日次ルールは無効状態（`enabled: false`）でデプロイされます**。実ジョブ（`daily-report`）未実装のうちは毎晩失敗して通知が飛ぶだけなので、`config.ts` の `batch.ruleEnabled` で切り替える設計にしています
- **マイグレーションは CDK のカスタムリソースにしていません**。失敗時のリカバリが難しいため、独立した ECS RunTask として明示的に実行します
- **dev ステージは使い捨て前提**。ECR は `emptyOnDelete` にしてあります（イメージが残っていると `cdk destroy` が失敗するため）。prod は RETAIN です

## コスト

`infra/README.md` に AWS Price List API の実測単価（ap-northeast-1）で内訳を書いています。

- 常時稼働なら **約 $64/月**（うち ALB + Fargate + IPv4 の常時起動分が約$40）
- ほぼ全部が時間課金なので、**1時間 約13円 / 半日 約160円**。使うときだけ立てて `cdk destroy` する運用向けです

## 確認

- `tsc --noEmit` … 通る
- `cdk synth` … 6スタックすべて成功。SGルール・cron・ルール無効状態・シークレット注入は合成結果を確認済み
- `cdk deploy` は未実行

---
_Generated by [Claude Code](https://claude.ai/code/session_01CeUN5RZC73bjv4BTU2MP4k)_