### PR TITLE
fix: 試合履歴のページ送りと勝率タブの500エラーを修正

### DIFF
--- a/apps/backend/src/analysis/analysis.usecase.spec.ts
+++ b/apps/backend/src/analysis/analysis.usecase.spec.ts
@@ -208,6 +208,72 @@ describe('AnalysisUseCase', () => {
         ).rejects.toThrow(ValidationException);
         expect(prismaService.$queryRaw).not.toHaveBeenCalled();
       });
+
+      it('should throw ValidationException for empty groupBy', async () => {
+        const userId = 'test-user-id';
+
+        await expect(
+          useCase.getVictoryRate({ userId, groupBy: [] }),
+        ).rejects.toThrow('groupBy must contain at least one field');
+        expect(prismaService.$queryRaw).not.toHaveBeenCalled();
+      });
+
+      it.each([
+        [VictoryRateSortBy.RULE_NAME, GroupByField.RULE],
+        [VictoryRateSortBy.STAGE_NAME, GroupByField.STAGE],
+        [VictoryRateSortBy.WEAPON_NAME, GroupByField.WEAPON],
+        [VictoryRateSortBy.BATTLE_TYPE_NAME, GroupByField.BATTLE_TYPE],
+      ])(
+        'should throw ValidationException when sorting by %s without grouping by %s',
+        async (sortBy, requiredGroupBy) => {
+          const userId = 'test-user-id';
+          const groupBy = Object.values(GroupByField).filter(
+            (field) => field !== requiredGroupBy,
+          );
+
+          await expect(
+            useCase.getVictoryRate({ userId, groupBy, sortBy }),
+          ).rejects.toThrow(ValidationException);
+          await expect(
+            useCase.getVictoryRate({ userId, groupBy, sortBy }),
+          ).rejects.toThrow(
+            `sortBy "${sortBy}" requires groupBy to include "${requiredGroupBy}"`,
+          );
+          expect(prismaService.$queryRaw).not.toHaveBeenCalled();
+        },
+      );
+
+      it('should allow sorting by a name column that is grouped by', async () => {
+        const userId = 'test-user-id';
+
+        prismaService.$queryRaw
+          .mockResolvedValueOnce([])
+          .mockResolvedValueOnce([{ count: BigInt(0) }]);
+
+        await expect(
+          useCase.getVictoryRate({
+            userId,
+            groupBy: [GroupByField.RULE, GroupByField.STAGE],
+            sortBy: VictoryRateSortBy.STAGE_NAME,
+          }),
+        ).resolves.toEqual({ victoryRates: [], total: 0 });
+      });
+
+      it('should allow sorting by an aggregate column regardless of groupBy', async () => {
+        const userId = 'test-user-id';
+
+        prismaService.$queryRaw
+          .mockResolvedValueOnce([])
+          .mockResolvedValueOnce([{ count: BigInt(0) }]);
+
+        await expect(
+          useCase.getVictoryRate({
+            userId,
+            groupBy: [GroupByField.WEAPON],
+            sortBy: VictoryRateSortBy.TOTAL_COUNT,
+          }),
+        ).resolves.toEqual({ victoryRates: [], total: 0 });
+      });
     });
 
     describe('sorting', () => {

--- a/apps/backend/src/analysis/analysis.usecase.ts
+++ b/apps/backend/src/analysis/analysis.usecase.ts
@@ -16,6 +16,17 @@ const ALLOWED_SORT_BY_FIELDS = new Set<string>(
 );
 const ALLOWED_SORT_ORDERS = new Set<string>(Object.values(SortOrder));
 
+// 名前カラムでのソートは、対応するフィールドでグルーピングしている場合のみ有効。
+// グルーピングされていない名前カラムは SELECT されないため、ORDER BY に指定すると SQL エラーになる。
+const SORT_BY_REQUIRED_GROUP_BY: Partial<
+  Record<VictoryRateSortBy, GroupByField>
+> = {
+  [VictoryRateSortBy.RULE_NAME]: GroupByField.RULE,
+  [VictoryRateSortBy.STAGE_NAME]: GroupByField.STAGE,
+  [VictoryRateSortBy.WEAPON_NAME]: GroupByField.WEAPON,
+  [VictoryRateSortBy.BATTLE_TYPE_NAME]: GroupByField.BATTLE_TYPE,
+};
+
 type VictoryRateRawResult = {
   rule_name?: string;
   stage_name?: string;
@@ -118,6 +129,10 @@ export class AnalysisUseCase {
   }
 
   private validateParams(params: GetVictoryRateParams): void {
+    if (params.groupBy.length === 0) {
+      throw new ValidationException('groupBy must contain at least one field');
+    }
+
     for (const field of params.groupBy) {
       if (!ALLOWED_GROUP_BY_FIELDS.has(field)) {
         throw new ValidationException(`Invalid groupBy field: ${field}`);
@@ -126,6 +141,15 @@ export class AnalysisUseCase {
 
     if (params.sortBy && !ALLOWED_SORT_BY_FIELDS.has(params.sortBy)) {
       throw new ValidationException(`Invalid sortBy field: ${params.sortBy}`);
+    }
+
+    if (params.sortBy) {
+      const requiredGroupBy = SORT_BY_REQUIRED_GROUP_BY[params.sortBy];
+      if (requiredGroupBy && !params.groupBy.includes(requiredGroupBy)) {
+        throw new ValidationException(
+          `sortBy "${params.sortBy}" requires groupBy to include "${requiredGroupBy}"`,
+        );
+      }
     }
 
     if (params.sortOrder && !ALLOWED_SORT_ORDERS.has(params.sortOrder)) {

--- a/apps/frontend/src/components/features/dashboard/VictoryRateTab.tsx
+++ b/apps/frontend/src/components/features/dashboard/VictoryRateTab.tsx
@@ -1,6 +1,10 @@
 import { Card, Checkbox, Typography, Space, Flex } from "antd";
 import { useState } from "react";
-import { useVictoryRate, type GroupByField, type VictoryRateSortBy } from "../../../hooks/useAnalysis";
+import {
+  useVictoryRate,
+  type GroupByField,
+  type VictoryRateSortBy,
+} from "../../../hooks/useAnalysis";
 import { useTableState } from "../../../hooks/useTableState";
 import { VictoryRateTable } from "./VictoryRateTable";
 
@@ -13,14 +17,24 @@ const GROUP_BY_OPTIONS: { label: string; value: GroupByField }[] = [
   { label: "バトルタイプ", value: "battleType" },
 ];
 
+const DEFAULT_SORT_BY: VictoryRateSortBy = "victoryRate";
+
+// 名前カラムのソートは、対応するグルーピングが有効なときのみバックエンドで扱える
+const SORT_BY_REQUIRED_GROUP_BY: Partial<Record<VictoryRateSortBy, GroupByField>> = {
+  ruleName: "rule",
+  stageName: "stage",
+  weaponName: "weapon",
+  battleTypeName: "battleType",
+};
+
 function isGroupByField(value: string): value is GroupByField {
   return ["rule", "stage", "weapon", "battleType"].includes(value);
 }
 
 export function VictoryRateTab() {
   const [selectedGroupBy, setSelectedGroupBy] = useState<GroupByField[]>(["rule"]);
-  const { tableState, setTableState, resetPage } = useTableState<VictoryRateSortBy>({
-    defaultSortBy: "victoryRate",
+  const { tableState, setTableState } = useTableState<VictoryRateSortBy>({
+    defaultSortBy: DEFAULT_SORT_BY,
   });
 
   const { data, isLoading } = useVictoryRate({
@@ -35,7 +49,16 @@ export function VictoryRateTab() {
   const handleGroupByChange = (checkedValues: string[]) => {
     const validValues = checkedValues.filter(isGroupByField);
     setSelectedGroupBy(validValues);
-    resetPage();
+
+    // グルーピングから外れた列でソートしたままだとリクエストが不正になるため、既定のソートに戻す
+    const requiredGroupBy = SORT_BY_REQUIRED_GROUP_BY[tableState.sortBy];
+    const isSortByAvailable = !requiredGroupBy || validValues.includes(requiredGroupBy);
+
+    setTableState({
+      ...tableState,
+      page: 1,
+      sortBy: isSortByAvailable ? tableState.sortBy : DEFAULT_SORT_BY,
+    });
   };
 
   return (

--- a/apps/frontend/src/components/features/matches/MatchTable.tsx
+++ b/apps/frontend/src/components/features/matches/MatchTable.tsx
@@ -10,6 +10,12 @@ import { useRules } from "../../../hooks/useRule";
 import { useStages } from "../../../hooks/useStage";
 import { useWeapons } from "../../../hooks/useWeapon";
 
+export type MatchTableState = {
+  page: number;
+  sortBy?: SearchMatchesRequest.sortBy;
+  sortOrder?: SearchMatchesRequest.sortOrder;
+};
+
 type MatchTableProps = {
   matches?: MatchResponse[];
   isLoading: boolean;
@@ -17,14 +23,10 @@ type MatchTableProps = {
     current: number;
     pageSize: number;
     total: number;
-    onChange: (page: number) => void;
   };
   sortBy?: SearchMatchesRequest.sortBy;
   sortOrder?: SearchMatchesRequest.sortOrder;
-  onSortChange?: (
-    sortBy: SearchMatchesRequest.sortBy,
-    sortOrder: SearchMatchesRequest.sortOrder
-  ) => void;
+  onTableChange: (state: MatchTableState) => void;
   selectedRowKeys?: string[];
   onSelectionChange?: (selectedKeys: string[], selectedRows: MatchResponse[]) => void;
 };
@@ -62,7 +64,7 @@ export function MatchTable({
   pagination,
   sortBy,
   sortOrder,
-  onSortChange,
+  onTableChange,
   selectedRowKeys,
   onSelectionChange,
 }: MatchTableProps) {
@@ -158,24 +160,36 @@ export function MatchTable({
     },
   ];
 
-  const handleTableChange: TableProps<TableRow>["onChange"] = (_pagination, _filters, sorter) => {
-    if (!onSortChange) return;
+  // antd calls this for both pagination and sorting changes, and it always reports the
+  // currently active sorter. Sorting and paging must therefore be resolved together:
+  // handling them separately made a page change also look like a sort change and reset
+  // the page back to 1.
+  const handleTableChange: TableProps<TableRow>["onChange"] = (
+    nextPagination,
+    _filters,
+    sorter
+  ) => {
     // sorter can be an array for multi-column sort, but we only support single
     const singleSorter = Array.isArray(sorter) ? sorter[0] : sorter;
-    // Only handle when column header is clicked (column property exists)
-    if (!singleSorter || !singleSorter.column) return;
 
-    const field = String(singleSorter.field);
-    const newSortBy = dataIndexToSortBy[field];
-    if (!newSortBy) return;
+    let newSortBy = sortBy;
+    let newSortOrder = sortOrder;
+    // column is only set while a sorter is active
+    if (singleSorter?.column) {
+      const mappedSortBy = dataIndexToSortBy[String(singleSorter.field)];
+      if (mappedSortBy) {
+        newSortBy = mappedSortBy;
+        newSortOrder =
+          singleSorter.order === "ascend"
+            ? SearchMatchesRequest.sortOrder.ASC
+            : SearchMatchesRequest.sortOrder.DESC;
+      }
+    }
 
-    // If clicking same column, toggle order; if no order, default to desc
-    const newSortOrder =
-      singleSorter.order === "ascend"
-        ? SearchMatchesRequest.sortOrder.ASC
-        : SearchMatchesRequest.sortOrder.DESC;
+    const sortChanged = newSortBy !== sortBy || newSortOrder !== sortOrder;
+    const newPage = sortChanged ? 1 : (nextPagination.current ?? pagination.current);
 
-    onSortChange(newSortBy, newSortOrder);
+    onTableChange({ page: newPage, sortBy: newSortBy, sortOrder: newSortOrder });
   };
 
   const rowSelection = onSelectionChange
@@ -216,7 +230,6 @@ export function MatchTable({
           pageSize: pagination.pageSize,
           total: pagination.total,
           showSizeChanger: false,
-          onChange: pagination.onChange,
         }}
         onChange={handleTableChange}
       />

--- a/apps/frontend/src/hooks/useAnalysis.ts
+++ b/apps/frontend/src/hooks/useAnalysis.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { AnalysisService } from "../api";
 
 export type GroupByField = "rule" | "stage" | "weapon" | "battleType";
@@ -40,6 +40,9 @@ export function useVictoryRate(params: UseVictoryRateParams) {
         params.sortOrder,
         params.sortBy
       ),
+    // Keep the previous page rendered while the next one loads so `total` (and with it the
+    // pager) does not momentarily collapse to 0
+    placeholderData: keepPreviousData,
     enabled: params.enabled !== false && params.groupBy.length > 0,
   });
 }

--- a/apps/frontend/src/hooks/useMatch.ts
+++ b/apps/frontend/src/hooks/useMatch.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useMutation, useQuery } from "@tanstack/react-query";
 import { MatchesService } from "../api";
 import type {
   BulkCreateMatchesRequest,
@@ -18,6 +18,9 @@ export function useSearchMatches(searchParams: SearchMatchesRequest) {
   return useQuery({
     queryKey: ["matches", "search", searchParams],
     queryFn: () => MatchesService.matchControllerSearchMatches(searchParams),
+    // Keep the previous page rendered while the next one loads so `total` (and with it the
+    // pager) does not momentarily collapse to 0
+    placeholderData: keepPreviousData,
     enabled: !!searchParams.operator,
   });
 }

--- a/apps/frontend/src/pages/MatchesPage.tsx
+++ b/apps/frontend/src/pages/MatchesPage.tsx
@@ -10,7 +10,7 @@ import { Button } from "../components/base";
 import { MatchDeleteConfirmModal } from "../components/features/matches/MatchDeleteConfirmModal";
 import { MatchEditModal } from "../components/features/matches/MatchEditModal";
 import { MatchSearchFilters } from "../components/features/matches/MatchSearchFilters";
-import { MatchTable } from "../components/features/matches/MatchTable";
+import { MatchTable, type MatchTableState } from "../components/features/matches/MatchTable";
 import { MainLayout } from "../components/layout/MainLayout";
 import { useNotification } from "../contexts/NotificationContext";
 import { useBulkUpdateMatches, useSearchMatches } from "../hooks/useMatch";
@@ -78,11 +78,8 @@ export function MatchesPage() {
     setFilters((prev) => ({ ...prev, ...newFilters, page: 1 }));
   };
 
-  const handleSortChange = (
-    sortBy: SearchMatchesRequest.sortBy,
-    sortOrder: SearchMatchesRequest.sortOrder
-  ) => {
-    setFilters((prev) => ({ ...prev, sortBy, sortOrder, page: 1 }));
+  const handleTableChange = ({ page, sortBy, sortOrder }: MatchTableState) => {
+    setFilters((prev) => ({ ...prev, page, sortBy, sortOrder }));
   };
 
   const handleSelectionChange = (keys: string[], rows: MatchResponse[]) => {
@@ -171,11 +168,10 @@ export function MatchesPage() {
               current: filters.page,
               pageSize: filters.pageCount,
               total: searchData?.total ?? 0,
-              onChange: (page) => setFilters((prev) => ({ ...prev, page })),
             }}
             sortBy={filters.sortBy}
             sortOrder={filters.sortOrder}
-            onSortChange={handleSortChange}
+            onTableChange={handleTableChange}
             selectedRowKeys={selectedRowKeys}
             onSelectionChange={handleSelectionChange}
           />


### PR DESCRIPTION
## 試合履歴画面でページ送りが効かない

MatchTable が antd Table の `onChange` と `pagination.onChange` の両方を
使っていた。antd はページ変更時にも `onChange` を呼び、その際 sorter には
「現在有効なソート」がそのまま入る。そのため `pagination.onChange` が
page を進めた直後に `onSortChange` が発火して page が 1 に戻され、
ページが切り替わらないように見えていた。

ページングとソートを 1 つのハンドラ（`onTableChange`）で同時に解決し、
ソートが実際に変化したときだけ page を 1 に戻すようにした
(VictoryRateTable と同じ方式)。

## 勝率タブで条件を切り替えると 500 が返る

名前カラム(ruleName など)でソートした状態でグルーピングのチェックを外すと、
SELECT されていない別名を ORDER BY に指定した SQL が生成され、MySQL が
Unknown column エラーを返して 500 になっていた。

- frontend: グルーピングから外れた列でソート中だった場合、既定のソート
  (victoryRate) に戻してからリクエストする
- backend: sortBy と groupBy の整合性を検証し、不整合なら
  ValidationException (400) を投げる。groupBy が空のケースも同様に弾く

あわせて、ページ遷移中に total が一時的に 0 になりページャが 1 に
見えてしまうのを防ぐため、ページングするクエリに keepPreviousData を設定した。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WKmfLwUyy8XxYzX7m19cYH