### PR TITLE
feat(frontend): record a whole play session instead of one match at a time

### DIFF
--- a/apps/frontend/src/components/features/matches/MatchSessionBar.tsx
+++ b/apps/frontend/src/components/features/matches/MatchSessionBar.tsx
@@ -1,0 +1,147 @@
+import { Col, DatePicker, Form, Row, Select } from "antd";
+import dayjs from "dayjs";
+import type { Control, FieldErrors } from "react-hook-form";
+import { Controller } from "react-hook-form";
+import type { BattleType, Rule, Stage } from "../../../api";
+import { Card } from "../../base";
+import { useRecentIds } from "../../../hooks/useRecentIds";
+import { withRecentFirst } from "../../../utils/selectOptions";
+import type { MatchSessionFormData } from "./sessionMatchColumns";
+
+const RECENT_STAGES_KEY = "spla:recent-stage-ids";
+
+interface MatchSessionBarProps {
+  control: Control<MatchSessionFormData>;
+  errors: FieldErrors<MatchSessionFormData>;
+  stages: Stage[] | undefined;
+  rules: Rule[] | undefined;
+  battleTypes: BattleType[] | undefined;
+  /** Lets the page seed rows that have no stage yet. */
+  onStageChange: (stageId: number) => void;
+}
+
+/**
+ * The conditions that hold for a whole play session.
+ *
+ * Date, battle type and rule barely change while you are playing, so asking for
+ * them once here removes three fields from every match below. The stage seeds
+ * new rows; each row can still override it.
+ */
+export function MatchSessionBar({
+  control,
+  errors,
+  stages,
+  rules,
+  battleTypes,
+  onStageChange,
+}: MatchSessionBarProps) {
+  const { recentIds: recentStageIds } = useRecentIds(RECENT_STAGES_KEY);
+
+  const stageOptions = withRecentFirst(
+    stages?.map((stage) => ({ label: stage.name, value: stage.id })) ?? [],
+    recentStageIds,
+    { recent: "最近のステージ", all: "すべてのステージ" }
+  );
+
+  return (
+    <Card size="small" title="このセッションの条件">
+      {/*
+        component={false} so this does not render a nested <form>: the page already
+        wraps the whole session (bar + rows + submit) in one form element.
+      */}
+      <Form component={false} layout="vertical" size="middle">
+        <div style={{ marginBottom: -16 }}>
+          <Row gutter={16}>
+            <Col xs={24} sm={12} lg={6}>
+              <Form.Item
+                label="日付"
+                validateStatus={errors.session?.date ? "error" : ""}
+                help={errors.session?.date?.message}
+              >
+                <Controller
+                  name="session.date"
+                  control={control}
+                  render={({ field }) => (
+                    <DatePicker
+                      style={{ width: "100%" }}
+                      allowClear={false}
+                      value={field.value ? dayjs(field.value) : null}
+                      onChange={(date) => field.onChange(date ? date.format("YYYY-MM-DD") : "")}
+                    />
+                  )}
+                />
+              </Form.Item>
+            </Col>
+
+            <Col xs={24} sm={12} lg={6}>
+              <Form.Item
+                label="バトルタイプ"
+                validateStatus={errors.session?.battleTypeId ? "error" : ""}
+                help={errors.session?.battleTypeId?.message}
+              >
+                <Controller
+                  name="session.battleTypeId"
+                  control={control}
+                  render={({ field }) => (
+                    <Select
+                      {...field}
+                      style={{ width: "100%" }}
+                      placeholder="選択"
+                      options={battleTypes?.map((bt) => ({ label: bt.name, value: bt.id }))}
+                    />
+                  )}
+                />
+              </Form.Item>
+            </Col>
+
+            <Col xs={24} sm={12} lg={6}>
+              <Form.Item
+                label="ルール"
+                validateStatus={errors.session?.ruleId ? "error" : ""}
+                help={errors.session?.ruleId?.message}
+              >
+                <Controller
+                  name="session.ruleId"
+                  control={control}
+                  render={({ field }) => (
+                    <Select
+                      {...field}
+                      style={{ width: "100%" }}
+                      placeholder="選択"
+                      options={rules?.map((rule) => ({ label: rule.name, value: rule.id }))}
+                    />
+                  )}
+                />
+              </Form.Item>
+            </Col>
+
+            <Col xs={24} sm={12} lg={6}>
+              <Form.Item label="ステージ" extra="追加する行の初期値になります">
+                <Controller
+                  name="session.stageId"
+                  control={control}
+                  render={({ field }) => (
+                    <Select
+                      {...field}
+                      style={{ width: "100%" }}
+                      placeholder="選択"
+                      showSearch
+                      optionFilterProp="label"
+                      options={stageOptions}
+                      onChange={(stageId) => {
+                        field.onChange(stageId);
+                        if (typeof stageId === "number") {
+                          onStageChange(stageId);
+                        }
+                      }}
+                    />
+                  )}
+                />
+              </Form.Item>
+            </Col>
+          </Row>
+        </div>
+      </Form>
+    </Card>
+  );
+}

--- a/apps/frontend/src/components/features/matches/MatchSessionBar.tsx
+++ b/apps/frontend/src/components/features/matches/MatchSessionBar.tsx
@@ -10,22 +10,27 @@ import type { MatchSessionFormData } from "./sessionMatchColumns";
 
 const RECENT_STAGES_KEY = "spla:recent-stage-ids";
 
+/** A 2-hour rotation runs exactly two stages. */
+export const MAX_ROTATION_STAGES = 2;
+
 interface MatchSessionBarProps {
   control: Control<MatchSessionFormData>;
   errors: FieldErrors<MatchSessionFormData>;
   stages: Stage[] | undefined;
   rules: Rule[] | undefined;
   battleTypes: BattleType[] | undefined;
-  /** Lets the page seed rows that have no stage yet. */
-  onStageChange: (stageId: number) => void;
+  /** Lets the page seed rows when the rotation turns out to have a single stage. */
+  onStagesChange: (stageIds: number[]) => void;
 }
 
 /**
  * The conditions that hold for a whole play session.
  *
  * Date, battle type and rule barely change while you are playing, so asking for
- * them once here removes three fields from every match below. The stage seeds
- * new rows; each row can still override it.
+ * them once here removes three fields from every match below.
+ *
+ * Stage is different: a rotation runs two of them and each match draws one, so
+ * this collects the pair and every match picks which one it was.
  */
 export function MatchSessionBar({
   control,
@@ -33,7 +38,7 @@ export function MatchSessionBar({
   stages,
   rules,
   battleTypes,
-  onStageChange,
+  onStagesChange,
 }: MatchSessionBarProps) {
   const { recentIds: recentStageIds } = useRecentIds(RECENT_STAGES_KEY);
 
@@ -116,23 +121,35 @@ export function MatchSessionBar({
             </Col>
 
             <Col xs={24} sm={12} lg={6}>
-              <Form.Item label="ステージ" extra="追加する行の初期値になります">
+              <Form.Item
+                label="ステージ"
+                extra="この時間帯の2つを選ぶと、試合ごとに切り替えられます"
+                validateStatus={errors.session?.stageIds ? "error" : ""}
+                help={
+                  Array.isArray(errors.session?.stageIds)
+                    ? undefined
+                    : errors.session?.stageIds?.message
+                }
+              >
                 <Controller
-                  name="session.stageId"
+                  name="session.stageIds"
                   control={control}
                   render={({ field }) => (
                     <Select
                       {...field}
+                      mode="multiple"
                       style={{ width: "100%" }}
-                      placeholder="選択"
+                      placeholder="2つまで選択"
                       showSearch
                       optionFilterProp="label"
                       options={stageOptions}
-                      onChange={(stageId) => {
-                        field.onChange(stageId);
-                        if (typeof stageId === "number") {
-                          onStageChange(stageId);
-                        }
+                      value={field.value ?? []}
+                      onChange={(stageIds: number[]) => {
+                        // A rotation runs two stages; keep the two most recently
+                        // picked rather than silently ignoring the new one.
+                        const capped = stageIds.slice(-MAX_ROTATION_STAGES);
+                        field.onChange(capped);
+                        onStagesChange(capped);
                       }}
                     />
                   )}

--- a/apps/frontend/src/components/features/matches/sessionMatchColumns.tsx
+++ b/apps/frontend/src/components/features/matches/sessionMatchColumns.tsx
@@ -27,7 +27,12 @@ export type MatchSessionFormData = {
     date: string;
     battleTypeId?: number;
     ruleId?: number;
-    stageId?: number;
+    /**
+     * The stages in this rotation. A 2-hour rotation runs two stages and each
+     * match draws one of them, so this holds up to two - never one "session
+     * stage" that every match inherits.
+     */
+    stageIds: number[];
   };
   matches: SessionMatchField[];
 };
@@ -41,6 +46,8 @@ type SessionMatchColumnsParams = {
   stages: Stage[] | undefined;
   recentWeaponIds: number[];
   recentStageIds: number[];
+  /** The rotation's stages, used to offer a 2-way choice per match. */
+  sessionStageIds: number[];
 };
 
 function rowError(errors: FieldErrors<MatchSessionFormData>, index: number) {
@@ -56,7 +63,15 @@ export function createSessionMatchColumns({
   stages,
   recentWeaponIds,
   recentStageIds,
+  sessionStageIds,
 }: SessionMatchColumnsParams): TableColumnsType<SessionMatchField> {
+  const stageById = new Map((stages ?? []).map((stage) => [stage.id, stage.name]));
+  const rotationStages = sessionStageIds
+    .map((id) => ({ id, name: stageById.get(id) }))
+    .filter((stage): stage is { id: number; name: string } => stage.name !== undefined);
+  // Two stages in the rotation: offer exactly those, as one tap and with no
+  // preselection. Guessing here would be wrong about half the time.
+  const hasRotationChoice = rotationStages.length >= 2;
   const weaponOptions = withRecentFirst(
     weapons?.map((weapon) => ({ label: weapon.name, value: weapon.id })) ?? [],
     recentWeaponIds,
@@ -107,22 +122,30 @@ export function createSessionMatchColumns({
       title: "ステージ",
       dataIndex: "stageId",
       key: "stageId",
-      width: 200,
+      width: hasRotationChoice ? 260 : 200,
       render: (_: unknown, __: unknown, index: number) => (
         <Controller
           name={`matches.${index}.stageId`}
           control={control}
-          render={({ field }) => (
-            <Select
-              {...field}
-              style={{ width: "100%" }}
-              placeholder="選択してください"
-              status={rowError(errors, index)?.stageId ? "error" : ""}
-              showSearch
-              optionFilterProp="label"
-              options={stageOptions}
-            />
-          )}
+          render={({ field }) =>
+            hasRotationChoice ? (
+              <Radio.Group
+                {...field}
+                optionType="button"
+                options={rotationStages.map((stage) => ({ label: stage.name, value: stage.id }))}
+              />
+            ) : (
+              <Select
+                {...field}
+                style={{ width: "100%" }}
+                placeholder="選択してください"
+                status={rowError(errors, index)?.stageId ? "error" : ""}
+                showSearch
+                optionFilterProp="label"
+                options={stageOptions}
+              />
+            )
+          }
         />
       ),
     },

--- a/apps/frontend/src/components/features/matches/sessionMatchColumns.tsx
+++ b/apps/frontend/src/components/features/matches/sessionMatchColumns.tsx
@@ -1,0 +1,208 @@
+import { DeleteOutlined } from "@ant-design/icons";
+import type { TableColumnsType } from "antd";
+import { InputNumber, Radio, Select, TimePicker, Typography } from "antd";
+import dayjs from "dayjs";
+import type { Control, FieldErrors } from "react-hook-form";
+import { Controller } from "react-hook-form";
+import type { Stage, WeaponResponse } from "../../../api";
+import { Button } from "../../base";
+import { withRecentFirst } from "../../../utils/selectOptions";
+
+const { Text } = Typography;
+
+export const TIME_FORMAT = "HH:mm";
+
+/** One match within a session. Date, battle type and rule live on the session. */
+export type SessionMatchField = {
+  id: string;
+  weaponId?: number;
+  stageId?: number;
+  result?: "WIN" | "LOSE";
+  time?: string;
+  point?: number | null;
+};
+
+export type MatchSessionFormData = {
+  session: {
+    date: string;
+    battleTypeId?: number;
+    ruleId?: number;
+    stageId?: number;
+  };
+  matches: SessionMatchField[];
+};
+
+type SessionMatchColumnsParams = {
+  control: Control<MatchSessionFormData>;
+  errors: FieldErrors<MatchSessionFormData>;
+  fieldsLength: number;
+  remove: (index: number) => void;
+  weapons: WeaponResponse[] | undefined;
+  stages: Stage[] | undefined;
+  recentWeaponIds: number[];
+  recentStageIds: number[];
+};
+
+function rowError(errors: FieldErrors<MatchSessionFormData>, index: number) {
+  return Array.isArray(errors.matches) ? errors.matches[index] : undefined;
+}
+
+export function createSessionMatchColumns({
+  control,
+  errors,
+  fieldsLength,
+  remove,
+  weapons,
+  stages,
+  recentWeaponIds,
+  recentStageIds,
+}: SessionMatchColumnsParams): TableColumnsType<SessionMatchField> {
+  const weaponOptions = withRecentFirst(
+    weapons?.map((weapon) => ({ label: weapon.name, value: weapon.id })) ?? [],
+    recentWeaponIds,
+    { recent: "最近使ったブキ", all: "すべてのブキ" }
+  );
+
+  const stageOptions = withRecentFirst(
+    stages?.map((stage) => ({ label: stage.name, value: stage.id })) ?? [],
+    recentStageIds,
+    { recent: "最近のステージ", all: "すべてのステージ" }
+  );
+
+  return [
+    {
+      title: "#",
+      key: "index",
+      width: 48,
+      render: (_: unknown, __: unknown, index: number) => (
+        <Text type="secondary" style={{ fontVariantNumeric: "tabular-nums" }}>
+          {index + 1}
+        </Text>
+      ),
+    },
+    {
+      title: "ブキ",
+      dataIndex: "weaponId",
+      key: "weaponId",
+      width: 220,
+      render: (_: unknown, __: unknown, index: number) => (
+        <Controller
+          name={`matches.${index}.weaponId`}
+          control={control}
+          render={({ field }) => (
+            <Select
+              {...field}
+              style={{ width: "100%" }}
+              placeholder="選択してください"
+              status={rowError(errors, index)?.weaponId ? "error" : ""}
+              showSearch
+              optionFilterProp="label"
+              options={weaponOptions}
+            />
+          )}
+        />
+      ),
+    },
+    {
+      title: "ステージ",
+      dataIndex: "stageId",
+      key: "stageId",
+      width: 200,
+      render: (_: unknown, __: unknown, index: number) => (
+        <Controller
+          name={`matches.${index}.stageId`}
+          control={control}
+          render={({ field }) => (
+            <Select
+              {...field}
+              style={{ width: "100%" }}
+              placeholder="選択してください"
+              status={rowError(errors, index)?.stageId ? "error" : ""}
+              showSearch
+              optionFilterProp="label"
+              options={stageOptions}
+            />
+          )}
+        />
+      ),
+    },
+    {
+      title: "勝敗",
+      dataIndex: "result",
+      key: "result",
+      width: 150,
+      render: (_: unknown, __: unknown, index: number) => (
+        <Controller
+          name={`matches.${index}.result`}
+          control={control}
+          render={({ field }) => (
+            <Radio.Group
+              {...field}
+              optionType="button"
+              options={[
+                { label: "勝ち", value: "WIN" },
+                { label: "負け", value: "LOSE" },
+              ]}
+            />
+          )}
+        />
+      ),
+    },
+    {
+      title: "ポイント",
+      dataIndex: "point",
+      key: "point",
+      width: 120,
+      render: (_: unknown, __: unknown, index: number) => (
+        <Controller
+          name={`matches.${index}.point`}
+          control={control}
+          render={({ field }) => (
+            <InputNumber
+              {...field}
+              value={field.value ?? undefined}
+              style={{ width: "100%" }}
+              placeholder="任意"
+              min={0}
+            />
+          )}
+        />
+      ),
+    },
+    {
+      title: "時刻",
+      dataIndex: "time",
+      key: "time",
+      width: 120,
+      render: (_: unknown, __: unknown, index: number) => (
+        <Controller
+          name={`matches.${index}.time`}
+          control={control}
+          render={({ field }) => (
+            <TimePicker
+              format={TIME_FORMAT}
+              style={{ width: "100%" }}
+              allowClear={false}
+              value={field.value ? dayjs(field.value, TIME_FORMAT) : null}
+              onChange={(time) => field.onChange(time ? time.format(TIME_FORMAT) : "")}
+            />
+          )}
+        />
+      ),
+    },
+    {
+      title: "",
+      key: "action",
+      width: 56,
+      render: (_: unknown, __: unknown, index: number) => (
+        <Button
+          intent="dangerQuiet"
+          icon={<DeleteOutlined />}
+          aria-label={`${index + 1} 行目を削除`}
+          onClick={() => remove(index)}
+          disabled={fieldsLength === 1}
+        />
+      ),
+    },
+  ];
+}

--- a/apps/frontend/src/components/features/mypage/UserProfileEdit.tsx
+++ b/apps/frontend/src/components/features/mypage/UserProfileEdit.tsx
@@ -37,8 +37,8 @@ export const UserProfileEdit = ({ name, email, onCancel, onSuccess }: UserProfil
       updateMutation.mutate(filteredValues, {
         onSuccess: () => {
           notification.success({
-            title: "更新が完了しました！",
-            message: "ユーザー情報を更新しました",
+            title: "更新が完了しました",
+            description: "ユーザー情報を更新しました",
             placement: "topRight",
           });
           onSuccess();
@@ -46,7 +46,7 @@ export const UserProfileEdit = ({ name, email, onCancel, onSuccess }: UserProfil
         onError: (error: Error) => {
           notification.error({
             title: "更新に失敗しました",
-            message: `更新に失敗しました: ${error.message}`,
+            description: error.message,
             placement: "topRight",
           });
         },

--- a/apps/frontend/src/hooks/useRecentIds.ts
+++ b/apps/frontend/src/hooks/useRecentIds.ts
@@ -1,0 +1,50 @@
+import { useCallback, useState } from "react";
+
+/**
+ * Remembers the ids a player picked most recently, newest first.
+ *
+ * Kept in localStorage rather than on the server: it is a per-device
+ * convenience, not user data worth a table and an endpoint. Every access is
+ * guarded because storage throws in private windows and when site data is
+ * blocked.
+ */
+export function useRecentIds(storageKey: string, limit = 5) {
+  const [recentIds, setRecentIds] = useState<number[]>(() => read(storageKey, limit));
+
+  const remember = useCallback(
+    (ids: number[]) => {
+      setRecentIds((previous) => {
+        const merged = dedupe([...ids, ...previous]).slice(0, limit);
+        write(storageKey, merged);
+        return merged;
+      });
+    },
+    [storageKey, limit]
+  );
+
+  return { recentIds, remember };
+}
+
+function dedupe(ids: number[]): number[] {
+  return [...new Set(ids)];
+}
+
+function read(storageKey: string, limit: number): number[] {
+  try {
+    const raw = window.localStorage.getItem(storageKey);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((id): id is number => typeof id === "number").slice(0, limit);
+  } catch {
+    return [];
+  }
+}
+
+function write(storageKey: string, ids: number[]): void {
+  try {
+    window.localStorage.setItem(storageKey, JSON.stringify(ids));
+  } catch {
+    // Storage unavailable - the ordering is a convenience, so carry on without it.
+  }
+}

--- a/apps/frontend/src/hooks/useTableState.ts
+++ b/apps/frontend/src/hooks/useTableState.ts
@@ -26,11 +26,7 @@ const DEFAULT_PAGE_SIZE = 20;
 export function useTableState<TSortBy extends string>(
   options: UseTableStateOptions<TSortBy>
 ): UseTableStateReturn<TSortBy> {
-  const {
-    defaultSortBy,
-    defaultSortOrder = "desc",
-    pageSize = DEFAULT_PAGE_SIZE,
-  } = options;
+  const { defaultSortBy, defaultSortOrder = "desc", pageSize = DEFAULT_PAGE_SIZE } = options;
 
   const [tableState, setTableStateInternal] = useState<TableState<TSortBy>>({
     page: 1,

--- a/apps/frontend/src/pages/CreateMatchesPage.tsx
+++ b/apps/frontend/src/pages/CreateMatchesPage.tsx
@@ -1,45 +1,171 @@
 import { PlusOutlined, SaveOutlined } from "@ant-design/icons";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useNavigate } from "@tanstack/react-router";
-import { Flex, Space, Spin, Table, Typography } from "antd";
-import { PageHeader } from "../components/layout/PageHeader";
+import { Flex, Skeleton, Space, Table, Typography } from "antd";
+import dayjs from "dayjs";
+import { useMemo } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
 import { z } from "zod";
 import { CreateMatchBody } from "../api";
-import { MainLayout } from "../components/layout/MainLayout";
 import { Button } from "../components/base";
+import { MatchSessionBar } from "../components/features/matches/MatchSessionBar";
 import {
-  createMatchFormColumns,
-  type MatchFormData,
-} from "../components/features/matches/matchFormColumns";
+  createSessionMatchColumns,
+  TIME_FORMAT,
+  type MatchSessionFormData,
+  type SessionMatchField,
+} from "../components/features/matches/sessionMatchColumns";
+import { MainLayout } from "../components/layout/MainLayout";
+import { PageHeader } from "../components/layout/PageHeader";
 import { useNotification } from "../contexts/NotificationContext";
 import { useBattleTypes } from "../hooks/useBattleType";
 import { useBulkCreateMatches } from "../hooks/useMatch";
+import { useRecentIds } from "../hooks/useRecentIds";
 import { useRules } from "../hooks/useRule";
 import { useStages } from "../hooks/useStage";
 import { useWeapons } from "../hooks/useWeapon";
+import { formatDateTimeAsJstIso } from "../utils/date";
 
-const matchSchema = z.object({
-  matches: z
-    .array(
-      z.object({
-        id: z.string(),
-        weaponId: z.number().optional(),
-        stageId: z.number().optional(),
-        ruleId: z.number().optional(),
-        battleTypeId: z.number().optional(),
-        result: z.enum(["WIN", "LOSE"]).optional(),
-        gameDateTime: z.string().optional(),
-        point: z.number().min(0).optional().nullable(),
-      })
-    )
-    .min(1, "最低1試合は入力してください"),
-});
+const RECENT_WEAPONS_KEY = "spla:recent-weapon-ids";
+const RECENT_STAGES_KEY = "spla:recent-stage-ids";
+const LAST_SESSION_KEY = "spla:last-session";
 
 const { Text } = Typography;
 
-function isValidResult(result: string): result is CreateMatchBody.result {
-  return result === "WIN" || result === "LOSE";
+/**
+ * Required-ness is expressed with `superRefine` rather than required field types
+ * so the schema's output shape stays identical to the form's input shape - that
+ * keeps one type for the whole form while still producing per-field messages.
+ */
+const matchSessionSchema = z
+  .object({
+    session: z.object({
+      date: z.string().min(1, "日付を選択してください"),
+      battleTypeId: z.number().optional(),
+      ruleId: z.number().optional(),
+      stageId: z.number().optional(),
+    }),
+    matches: z
+      .array(
+        z.object({
+          id: z.string(),
+          weaponId: z.number().optional(),
+          stageId: z.number().optional(),
+          result: z.enum(["WIN", "LOSE"]).optional(),
+          time: z.string().optional(),
+          point: z.number().min(0).optional().nullable(),
+        })
+      )
+      .min(1, "最低1試合は入力してください"),
+  })
+  .superRefine((data, ctx) => {
+    if (data.session.battleTypeId === undefined) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["session", "battleTypeId"],
+        message: "バトルタイプを選択してください",
+      });
+    }
+    if (data.session.ruleId === undefined) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["session", "ruleId"],
+        message: "ルールを選択してください",
+      });
+    }
+    data.matches.forEach((match, index) => {
+      if (match.weaponId === undefined) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["matches", index, "weaponId"],
+          message: "ブキを選択してください",
+        });
+      }
+      if (match.stageId === undefined) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["matches", index, "stageId"],
+          message: "ステージを選択してください",
+        });
+      }
+      if (match.result === undefined) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["matches", index, "result"],
+          message: "勝敗を選択してください",
+        });
+      }
+      if (!match.time) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["matches", index, "time"],
+          message: "時刻を入力してください",
+        });
+      }
+    });
+  });
+
+/** A row that passed validation, narrowed without a type assertion. */
+type CompleteMatch = SessionMatchField & {
+  weaponId: number;
+  stageId: number;
+  result: "WIN" | "LOSE";
+  time: string;
+};
+
+function isComplete(match: SessionMatchField): match is CompleteMatch {
+  return (
+    match.weaponId !== undefined &&
+    match.stageId !== undefined &&
+    match.result !== undefined &&
+    typeof match.time === "string" &&
+    match.time.length > 0
+  );
+}
+
+/** Battle type / rule / stage carry over to the next visit; the date does not. */
+type StoredSession = { battleTypeId?: number; ruleId?: number; stageId?: number };
+
+function readStoredSession(): StoredSession {
+  try {
+    const raw = window.localStorage.getItem(LAST_SESSION_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) return {};
+    const asRecord: Record<string, unknown> = { ...parsed };
+    const pick = (key: string): number | undefined => {
+      const value = asRecord[key];
+      return typeof value === "number" ? value : undefined;
+    };
+    return {
+      battleTypeId: pick("battleTypeId"),
+      ruleId: pick("ruleId"),
+      stageId: pick("stageId"),
+    };
+  } catch {
+    return {};
+  }
+}
+
+function writeStoredSession(session: StoredSession): void {
+  try {
+    window.localStorage.setItem(LAST_SESSION_KEY, JSON.stringify(session));
+  } catch {
+    // Storage unavailable - the next visit just starts empty.
+  }
+}
+
+function newRow(overrides: Partial<SessionMatchField> = {}): SessionMatchField {
+  return {
+    id: crypto.randomUUID(),
+    weaponId: undefined,
+    stageId: undefined,
+    result: undefined,
+    // Defaults to now, so logging as you play needs no date picker at all.
+    time: dayjs().format(TIME_FORMAT),
+    point: undefined,
+    ...overrides,
+  };
 }
 
 export function CreateMatchesPage() {
@@ -52,182 +178,195 @@ export function CreateMatchesPage() {
   const { data: battleTypes, isLoading: isLoadingBattleTypes } = useBattleTypes();
   const { mutate: createMatches, isPending: isCreating } = useBulkCreateMatches();
 
+  const { recentIds: recentWeaponIds, remember: rememberWeapons } =
+    useRecentIds(RECENT_WEAPONS_KEY);
+  const { recentIds: recentStageIds, remember: rememberStages } = useRecentIds(RECENT_STAGES_KEY);
+
+  const storedSession = useMemo(readStoredSession, []);
+
   const {
     control,
     handleSubmit,
+    getValues,
+    setValue,
     formState: { errors },
-  } = useForm<MatchFormData>({
-    resolver: zodResolver(matchSchema),
+  } = useForm<MatchSessionFormData>({
+    resolver: zodResolver(matchSessionSchema),
     defaultValues: {
-      matches: [
-        {
-          id: crypto.randomUUID(),
-          weaponId: undefined,
-          stageId: undefined,
-          ruleId: undefined,
-          battleTypeId: undefined,
-          result: undefined,
-          gameDateTime: "",
-          point: undefined,
-        },
-      ],
+      session: {
+        date: dayjs().format("YYYY-MM-DD"),
+        battleTypeId: storedSession.battleTypeId,
+        ruleId: storedSession.ruleId,
+        stageId: storedSession.stageId,
+      },
+      matches: [newRow({ stageId: storedSession.stageId })],
     },
   });
 
-  const { fields, append, remove } = useFieldArray({
-    control,
-    name: "matches",
-  });
+  const { fields, append, remove } = useFieldArray({ control, name: "matches" });
 
   const isLoading = isLoadingWeapons || isLoadingStages || isLoadingRules || isLoadingBattleTypes;
 
-  const onSubmit = (data: MatchFormData) => {
-    // Validate and filter out incomplete rows using type guard
-    const validMatches = data.matches.filter(
-      (
-        match
-      ): match is typeof match & {
-        weaponId: number;
-        stageId: number;
-        ruleId: number;
-        battleTypeId: number;
-        result: "WIN" | "LOSE";
-        gameDateTime: string;
-      } =>
-        match.weaponId !== undefined &&
-        match.stageId !== undefined &&
-        match.ruleId !== undefined &&
-        match.battleTypeId !== undefined &&
-        match.result !== undefined &&
-        isValidResult(match.result) &&
-        match.gameDateTime !== undefined &&
-        match.gameDateTime !== ""
+  // Choosing the session stage fills rows that have none yet. Rows where a stage
+  // was already picked are left alone - this seeds blanks, it does not overwrite.
+  const handleSessionStageChange = (stageId: number) => {
+    getValues().matches.forEach((match, index) => {
+      if (match.stageId === undefined) {
+        setValue(`matches.${index}.stageId`, stageId, { shouldValidate: false });
+      }
+    });
+  };
+
+  // A new row copies the weapon and stage of the one above it: within a session
+  // those usually repeat, so the common case needs only the win/loss tap.
+  const handleAddRow = () => {
+    const current = getValues();
+    const previous = current.matches[current.matches.length - 1];
+    append(
+      newRow({
+        weaponId: previous?.weaponId,
+        stageId: previous?.stageId ?? current.session.stageId,
+      })
     );
+  };
 
-    if (validMatches.length === 0) {
-      notification.error({
-        title: "入力エラー",
-        message: "入力エラー",
-        description: "少なくとも1試合分の完全なデータを入力してください",
-        placement: "topRight",
-      });
-      return;
-    }
+  const onSubmit = (data: MatchSessionFormData) => {
+    const { session } = data;
+    const complete = data.matches.filter(isComplete);
+    // The resolver already blocks both of these; this is what narrows the types.
+    if (session.battleTypeId === undefined || session.ruleId === undefined) return;
+    if (complete.length !== data.matches.length) return;
 
-    // Convert to API format - map result to CreateMatchBody.result enum
+    const battleTypeId = session.battleTypeId;
+    const ruleId = session.ruleId;
+
     const payload = {
-      matches: validMatches.map((match) => ({
+      matches: complete.map((match) => ({
         weaponId: match.weaponId,
         stageId: match.stageId,
-        ruleId: match.ruleId,
-        battleTypeId: match.battleTypeId,
+        ruleId,
+        battleTypeId,
         result: match.result === "WIN" ? CreateMatchBody.result.WIN : CreateMatchBody.result.LOSE,
-        gameDateTime: match.gameDateTime,
+        gameDateTime: combineDateAndTime(session.date, match.time),
         point: match.point ?? undefined,
       })),
     };
 
     createMatches(payload, {
       onSuccess: () => {
+        rememberWeapons(complete.map((match) => match.weaponId));
+        rememberStages(complete.map((match) => match.stageId));
+        writeStoredSession({ battleTypeId, ruleId, stageId: session.stageId });
         notification.success({
-          title: "登録成功",
-          message: "登録成功",
-          description: "試合データを登録しました",
+          title: "登録しました",
+          description: `${payload.matches.length} 試合を登録しました`,
           placement: "topRight",
         });
         navigate({ to: "/matches" });
       },
       onError: (error) => {
         notification.error({
-          title: "登録失敗",
-          message: "登録失敗",
-          description: `登録に失敗しました: ${error.message}`,
+          title: "登録に失敗しました",
+          description: error.message,
           placement: "topRight",
         });
       },
     });
   };
 
-  const handleAddRow = () => {
-    append({
-      id: crypto.randomUUID(),
-      weaponId: undefined,
-      stageId: undefined,
-      ruleId: undefined,
-      battleTypeId: undefined,
-      result: undefined,
-      gameDateTime: "",
-      point: undefined,
-    });
-  };
-
   if (isLoading) {
     return (
       <MainLayout>
-        <Flex justify="center" align="center" style={{ height: 400 }}>
-          <Spin size="large" />
+        <Flex vertical gap="large">
+          <PageHeader title="試合を登録" />
+          <Skeleton active paragraph={{ rows: 6 }} />
         </Flex>
       </MainLayout>
     );
   }
 
-  const columns = createMatchFormColumns({
+  const columns = createSessionMatchColumns({
     control,
     errors,
     fieldsLength: fields.length,
     remove,
     weapons,
     stages,
-    rules,
-    battleTypes,
+    recentWeaponIds,
+    recentStageIds,
   });
+
+  const rowErrorCount = Array.isArray(errors.matches) ? errors.matches.filter(Boolean).length : 0;
 
   return (
     <MainLayout>
       <Flex vertical gap="large">
         <PageHeader
-          title="試合データ登録"
-          description="複数の試合を一度に登録できます。必要に応じて行を追加してください。"
+          title="試合を登録"
+          description="セッションの条件を上で決めると、あとは試合ごとにブキと勝敗だけで記録できます。"
         />
 
         <form onSubmit={handleSubmit(onSubmit)}>
-          <Table
-            dataSource={fields}
-            columns={columns}
-            rowKey="id"
-            pagination={false}
-            scroll={{ x: 1300 }}
-            bordered
-          />
+          <Flex vertical gap="large">
+            <MatchSessionBar
+              control={control}
+              errors={errors}
+              stages={stages}
+              rules={rules}
+              battleTypes={battleTypes}
+              onStageChange={handleSessionStageChange}
+            />
 
-          <Flex vertical align="flex-start" gap="middle" style={{ marginTop: 16 }}>
-            <Button intent="neutral" icon={<PlusOutlined />} onClick={handleAddRow}>
-              行を追加
-            </Button>
+            <Table
+              dataSource={fields}
+              columns={columns}
+              rowKey="id"
+              pagination={false}
+              size="middle"
+              scroll={{ x: "max-content" }}
+              bordered
+            />
 
-            {errors.matches && <Text type="danger">{errors.matches.message}</Text>}
-
-            <Space>
-              <Button
-                htmlType="submit"
-                intent="primary"
-                icon={<SaveOutlined />}
-                loading={isCreating}
-              >
-                登録する
+            <Flex vertical align="flex-start" gap="middle">
+              <Button intent="neutral" icon={<PlusOutlined />} onClick={handleAddRow}>
+                試合を追加
               </Button>
-              <Button
-                htmlType="button"
-                intent="neutral"
-                onClick={() => navigate({ to: "/matches" })}
-                disabled={isCreating}
-              >
-                キャンセル
-              </Button>
-            </Space>
+
+              {rowErrorCount > 0 && (
+                <Text type="danger">{rowErrorCount} 件の試合に未入力の項目があります</Text>
+              )}
+              {typeof errors.matches?.message === "string" && (
+                <Text type="danger">{errors.matches.message}</Text>
+              )}
+
+              <Space>
+                <Button
+                  htmlType="submit"
+                  intent="primary"
+                  icon={<SaveOutlined />}
+                  loading={isCreating}
+                >
+                  {fields.length} 試合を登録する
+                </Button>
+                <Button
+                  htmlType="button"
+                  intent="neutral"
+                  onClick={() => navigate({ to: "/matches" })}
+                  disabled={isCreating}
+                >
+                  キャンセル
+                </Button>
+              </Space>
+            </Flex>
           </Flex>
         </form>
       </Flex>
     </MainLayout>
   );
+}
+
+/** "2026-08-24" + "21:30" -> the ISO string the API expects. */
+function combineDateAndTime(date: string, time: string): string {
+  const [hour, minute] = time.split(":").map(Number);
+  return formatDateTimeAsJstIso(dayjs(date).hour(hour).minute(minute).second(0));
 }

--- a/apps/frontend/src/pages/CreateMatchesPage.tsx
+++ b/apps/frontend/src/pages/CreateMatchesPage.tsx
@@ -4,11 +4,14 @@ import { useNavigate } from "@tanstack/react-router";
 import { Flex, Skeleton, Space, Table, Typography } from "antd";
 import dayjs from "dayjs";
 import { useMemo } from "react";
-import { useFieldArray, useForm } from "react-hook-form";
+import { useFieldArray, useForm, useWatch } from "react-hook-form";
 import { z } from "zod";
 import { CreateMatchBody } from "../api";
 import { Button } from "../components/base";
-import { MatchSessionBar } from "../components/features/matches/MatchSessionBar";
+import {
+  MatchSessionBar,
+  MAX_ROTATION_STAGES,
+} from "../components/features/matches/MatchSessionBar";
 import {
   createSessionMatchColumns,
   TIME_FORMAT,
@@ -43,7 +46,7 @@ const matchSessionSchema = z
       date: z.string().min(1, "日付を選択してください"),
       battleTypeId: z.number().optional(),
       ruleId: z.number().optional(),
-      stageId: z.number().optional(),
+      stageIds: z.array(z.number()),
     }),
     matches: z
       .array(
@@ -123,27 +126,33 @@ function isComplete(match: SessionMatchField): match is CompleteMatch {
   );
 }
 
-/** Battle type / rule / stage carry over to the next visit; the date does not. */
-type StoredSession = { battleTypeId?: number; ruleId?: number; stageId?: number };
+/** Battle type / rule / stages carry over to the next visit; the date does not. */
+type StoredSession = { battleTypeId?: number; ruleId?: number; stageIds: number[] };
+
+const EMPTY_STORED_SESSION: StoredSession = { stageIds: [] };
 
 function readStoredSession(): StoredSession {
   try {
     const raw = window.localStorage.getItem(LAST_SESSION_KEY);
-    if (!raw) return {};
+    if (!raw) return EMPTY_STORED_SESSION;
     const parsed: unknown = JSON.parse(raw);
-    if (typeof parsed !== "object" || parsed === null) return {};
+    if (typeof parsed !== "object" || parsed === null) return EMPTY_STORED_SESSION;
     const asRecord: Record<string, unknown> = { ...parsed };
-    const pick = (key: string): number | undefined => {
+    const pickNumber = (key: string): number | undefined => {
       const value = asRecord[key];
       return typeof value === "number" ? value : undefined;
     };
+    const rawStageIds = asRecord.stageIds;
+    const stageIds = Array.isArray(rawStageIds)
+      ? rawStageIds.filter((id): id is number => typeof id === "number")
+      : [];
     return {
-      battleTypeId: pick("battleTypeId"),
-      ruleId: pick("ruleId"),
-      stageId: pick("stageId"),
+      battleTypeId: pickNumber("battleTypeId"),
+      ruleId: pickNumber("ruleId"),
+      stageIds: stageIds.slice(0, MAX_ROTATION_STAGES),
     };
   } catch {
-    return {};
+    return EMPTY_STORED_SESSION;
   }
 }
 
@@ -197,35 +206,43 @@ export function CreateMatchesPage() {
         date: dayjs().format("YYYY-MM-DD"),
         battleTypeId: storedSession.battleTypeId,
         ruleId: storedSession.ruleId,
-        stageId: storedSession.stageId,
+        stageIds: storedSession.stageIds,
       },
-      matches: [newRow({ stageId: storedSession.stageId })],
+      matches: [newRow()],
     },
   });
 
   const { fields, append, remove } = useFieldArray({ control, name: "matches" });
 
+  // The row cells need to re-render as the rotation's stages change.
+  const watchedStageIds = useWatch({ control, name: "session.stageIds" }) ?? [];
+
   const isLoading = isLoadingWeapons || isLoadingStages || isLoadingRules || isLoadingBattleTypes;
 
-  // Choosing the session stage fills rows that have none yet. Rows where a stage
-  // was already picked are left alone - this seeds blanks, it does not overwrite.
-  const handleSessionStageChange = (stageId: number) => {
+  // Nothing here ever picks a stage for the player. Changing the rotation only
+  // clears rows whose stage is no longer one of its two, so an edit cannot leave
+  // a match pointing at a stage that is not on offer any more.
+  const handleSessionStagesChange = (stageIds: number[]) => {
+    if (stageIds.length < MAX_ROTATION_STAGES) return;
     getValues().matches.forEach((match, index) => {
-      if (match.stageId === undefined) {
-        setValue(`matches.${index}.stageId`, stageId, { shouldValidate: false });
+      if (match.stageId !== undefined && !stageIds.includes(match.stageId)) {
+        setValue(`matches.${index}.stageId`, undefined, { shouldValidate: false });
       }
     });
   };
 
-  // A new row copies the weapon and stage of the one above it: within a session
-  // those usually repeat, so the common case needs only the win/loss tap.
+  // A new row copies the weapon of the one above it - players keep a weapon for a
+  // run of matches - but never the stage. See below.
   const handleAddRow = () => {
     const current = getValues();
     const previous = current.matches[current.matches.length - 1];
     append(
       newRow({
         weaponId: previous?.weaponId,
-        stageId: previous?.stageId ?? current.session.stageId,
+        // Stage is deliberately left blank. A rotation draws one of two stages per
+        // match, so carrying the previous one over - or defaulting to either -
+        // would be wrong about half the time, and a wrong value that looks filled
+        // in is worse than an empty one.
       })
     );
   };
@@ -256,7 +273,7 @@ export function CreateMatchesPage() {
       onSuccess: () => {
         rememberWeapons(complete.map((match) => match.weaponId));
         rememberStages(complete.map((match) => match.stageId));
-        writeStoredSession({ battleTypeId, ruleId, stageId: session.stageId });
+        writeStoredSession({ battleTypeId, ruleId, stageIds: session.stageIds });
         notification.success({
           title: "登録しました",
           description: `${payload.matches.length} 試合を登録しました`,
@@ -294,6 +311,7 @@ export function CreateMatchesPage() {
     stages,
     recentWeaponIds,
     recentStageIds,
+    sessionStageIds: watchedStageIds,
   });
 
   const rowErrorCount = Array.isArray(errors.matches) ? errors.matches.filter(Boolean).length : 0;
@@ -303,7 +321,7 @@ export function CreateMatchesPage() {
       <Flex vertical gap="large">
         <PageHeader
           title="試合を登録"
-          description="セッションの条件を上で決めると、あとは試合ごとにブキと勝敗だけで記録できます。"
+          description="セッションの条件を上で決めると、あとは試合ごとにステージと勝敗を選ぶだけです。"
         />
 
         <form onSubmit={handleSubmit(onSubmit)}>
@@ -314,7 +332,7 @@ export function CreateMatchesPage() {
               stages={stages}
               rules={rules}
               battleTypes={battleTypes}
-              onStageChange={handleSessionStageChange}
+              onStagesChange={handleSessionStagesChange}
             />
 
             <Table

--- a/apps/frontend/src/pages/MatchesPage.tsx
+++ b/apps/frontend/src/pages/MatchesPage.tsx
@@ -125,7 +125,6 @@ export function MatchesPage() {
         onSuccess: () => {
           notification.success({
             title: "更新成功",
-            message: "更新成功",
             description: "試合データを更新しました",
             placement: "topRight",
           });
@@ -137,7 +136,6 @@ export function MatchesPage() {
         onError: (error) => {
           notification.error({
             title: "更新失敗",
-            message: "更新失敗",
             description: `更新に失敗しました: ${error.message}`,
             placement: "topRight",
           });

--- a/apps/frontend/src/utils/selectOptions.ts
+++ b/apps/frontend/src/utils/selectOptions.ts
@@ -1,0 +1,39 @@
+import type { DefaultOptionType } from "antd/es/select";
+
+export type SelectOption = { label: string; value: number };
+
+/**
+ * Puts the most recently used entries at the top of a long select.
+ *
+ * There are 172 weapons and 23 stages in the master data, but one player uses a
+ * handful of each. Without this, every entry costs a scroll or a search even
+ * when the answer is the same as last time.
+ *
+ * Returns Ant Design's own option type so that the flat and grouped shapes are
+ * one array type - a union of the two makes `Select` unable to infer its value.
+ */
+export function withRecentFirst(
+  options: SelectOption[],
+  recentIds: number[],
+  labels: { recent: string; all: string }
+): DefaultOptionType[] {
+  if (recentIds.length === 0 || options.length === 0) {
+    return options;
+  }
+
+  const byValue = new Map(options.map((option) => [option.value, option]));
+  const recent = recentIds
+    .map((id) => byValue.get(id))
+    .filter((option): option is SelectOption => option !== undefined);
+
+  if (recent.length === 0) {
+    return options;
+  }
+
+  const recentValues = new Set(recent.map((option) => option.value));
+
+  return [
+    { label: labels.recent, options: recent },
+    { label: labels.all, options: options.filter((o) => !recentValues.has(o.value)) },
+  ];
+}


### PR DESCRIPTION
改善提案の1番目「セッション入力」の実装です。

試合の記録はこのアプリで**最も繰り返される作業**（1セッションで10〜20試合）でありながら、いちばん重い画面でした。毎行7項目すべてを入力する必要があり、しかも `gameDateTime` の初期値が `""` だったため、**1試合ごとに日時ピッカーを開く**必要がありました。10試合で70項目です。

## 何を変えたか

1セッション中は日付・バトルタイプ・ルールが固定なので、それらは**セッションバー**に集約しました。

**ステージは別扱いです。** 2時間のローテーションでは2ステージが試合ごとに抽選されるので、「セッションのステージ」を1つ決めて全行に引き継ぐのは**ゲームの仕様として誤り**です。セッションバーで**その時間帯の2ステージ**を選び、各試合はその2択トグルで記録します。**どちらも初期選択しません** — 引き継ぎや初期値は約半分の確率で誤りになり、「入力済みに見える値」は空欄より質が悪いためです。

- `session.stageIds` は2件までにキャップ（3つ目を選ぶと古いほうが外れる）
- 行を追加すると**ブキは引き継ぐ**（プレイヤーは何試合か同じブキを使う）が、**ステージは引き継がない**
- ローテーションを編集すると、外れたステージを指していた行のステージだけクリアされる
- 2ステージ未満のときは従来どおり全23件のセレクトにフォールバック

**その他** — 時刻は行追加時の現在時刻が初期値。長いセレクト（ブキ172件・ステージ23件）は「最近使った」を先頭にグループ表示（localStorage、API追加なし）。バトルタイプ / ルール / ステージは次回訪問時に復元（日付は復元しません）。

## 入力項目数（10試合・ブキを変えない場合）

| | 項目数 |
| --- | --- |
| Before | **70**（10試合 × 7項目） |
| After | **25**（セッション4 ＋ 1試合目3 ＋ 2試合目以降 2×9） |

1試合あたりは「ステージ」「勝敗」の2タップです。ブキも毎試合変える場合は34項目。

## 未入力の扱いを変えました

以前は未完成の行を**送信時に黙って捨てて**いました。ブキを選び忘れた試合が、記録されないまま消えていたことになります。今は送信をブロックし、該当セルにエラー表示＋ボタンの上に件数を出します。

## 実装中に見つけた2件の不具合も直しています

- **`<form>` の入れ子** — セッションバーの Ant Design `Form` が実際の `<form>` 要素を描画しており、ページ側の form の内側に入っていました。HTML として不正で、React が毎レンダリング警告を出していました。`component={false}` に変更。
- **Notification の非推奨 `message`** — Ant Design v6 で `title` に置き換えられており、通知が出るたびに警告が出ていました。該当4箇所を修正。

結果、**コンソールの警告・エラーはゼロ**になりました。

## 編集モーダルは変更していません

過去の任意の試合を編集する場面ではルール・バトルタイプ・日時が行ごとに必要なので、`matchFormColumns` とモーダルはそのままです。列構成が変わっていないことを実機で確認しました（ブキ / ステージ / ルール / バトル / 勝敗 / 日時 / ポイント / 操作）。

## 確認したこと

`tsc -b` ✓ / `vite build` ✓ / `eslint` 新規エラーなし（既存4件は未タッチのファイル）

実機での End-to-End 確認（本番と同じ172件のブキを返すモックを使用）:

```
時刻の初期値                  : "22:53" ✓
未入力での送信                : ブロック、POST 0件 ✓
1ステージ目を選んだ直後        : 行は未選択のまま ✓
2ステージ目を選んだ後          : 2択トグルを表示、未選択のまま ✓
3ステージ目を選択              : 直近2件にキャップ ✓
行追加                        : ブキは継承、ステージは未選択 ✓
ローテーションから外したステージ : その行だけクリア（他行は保持）✓
POST payload                  : stage=[1, 2] と試合ごとに異なる ✓
再訪問                        : セッション復元＋「最近使ったブキ」が先頭 ✓
編集モーダル                   : 列構成そのまま ✓
コンソール                     : クリーン ✓
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3zVbJGKqFHG2WrUnWQ2Jw